### PR TITLE
WIP: Run 'dep init' to create Gopkg.{toml,lock}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ INTERVAL ?= 86400
 build_cmd = mkdir -p _output && GOOS=linux go build -o _output/$(1) ./cmd/$(1)
 prepare_spec = sed 's,DOCKER_IMAGE,$(DOCKER_REPO),g'
 
+SHELL := /bin/bash
+
 build:
 	$(call build_cmd,collapsed-kube-commit-mapper)
 	$(call build_cmd,publishing-bot)
@@ -35,8 +37,9 @@ update-deps:
 .PHONY: update-deps
 
 init-deploy:
-	$(KUBECTL) delete -n "$(NAMESPACE)" rc publisher || true
-	$(KUBECTL) delete -n "$(NAMESPACE)" pod publisher || true
+	$(KUBECTL) delete -n "$(NAMESPACE)" --ignore-not-found=true rc publisher
+	$(KUBECTL) delete -n "$(NAMESPACE)" --ignore-not-found=true pod publisher
+	while $(KUBECTL) get pod publisher -a &>/dev/null; do echo -n .; sleep 1; done
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/storage-class.yaml || true
 	$(KUBECTL) get StorageClass ssd
 	sed 's/TOKEN/$(shell echo "$(TOKEN)" | base64 | tr -d '\n')/g' artifacts/manifests/secret.yaml | $(KUBECTL) apply -n "$(NAMESPACE)" -f -

--- a/artifacts/scripts/initialize_repos.sh
+++ b/artifacts/scripts/initialize_repos.sh
@@ -35,7 +35,7 @@ popd
 
 go get github.com/golang/dep
 pushd ${GOPATH}/src/github.com/golang/dep
-    git checkout 7c44971bbb9f0ed87db40b601f2d9fe4dffb750d
+    git checkout 3a59b68597c76c889b2ff2854b30bc29e902b555
     go install ./cmd/dep
 popd
 

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -621,6 +621,17 @@ function fix-godeps() {
         fi
     fi
 
+    # run golang dep
+    echo "Running dep init."
+    rm -rf vendor/
+    dep init -gopath
+    git add Gopkg.{toml,lock}
+    if ! git diff-index --quiet --cached HEAD -- ; then
+        git commit -q -m "sync: run golang/dep"
+    fi
+    rm -rf vendor/
+    git reset --hard
+
     # amend godep commit to ${dst_old_commit}
     if ! git diff --exit-code ${dst_old_commit} &>/dev/null && [ "${squash}" = true ]; then
         echo "Amending last merge with godep changes."


### PR DESCRIPTION
Golang/dep does not support picking up these dependencies yet properly. But at least
dep will warn the user when he chooses incompatible dependencies (so did @munnerz report, but with `dep init --gopath` I did not even get warnings, but it picked up master which it shouldn't).

A test run was published to https://github.com/kubernetes-dep-experiment/client-go

**The goal is to vendor k8s.io/client-go, api, apimachinery and all other direct and transistive dependencies of client-go in the versions that are specified in  https://github.com/kubernetes-dep-experiment/client-go's Gopkg.{toml,lock} with only specifying the right branch or tag of client-go, i.e.**

```
[[constraint]]
  name = "k8s.io/client-go"
  version = "5.0.1"
```

For testing purposes one has to define the source for client-go, api and apimachinery to be in the kubernetes-dep-experiment org:

```
[[constraint]]
  name = "k8s.io/client-go"
  version = "5.0.1"
  source = "https://github.com/kubernetes-dep-experiment/client-go.git"

[[constraint]]
  name = "k8s.io/api"
  source = "https://github.com/kubernetes-dep-experiment/api.git"

[[constraint]]
  name = "k8s.io/apimachinery"
  source = "https://github.com/kubernetes-dep-experiment/apimachinery.git"
```

Compare https://github.com/sttts/kube-dep-test/blob/master/Gopkg.toml for a test project.