### PR TITLE
Externalize the rule definition into a YAML file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ init-deploy:
 	$(KUBECTL) get StorageClass ssd
 	sed 's/TOKEN/$(shell echo "$(TOKEN)" | base64 | tr -d '\n')/g' artifacts/manifests/secret.yaml | $(KUBECTL) apply -n "$(NAMESPACE)" -f -
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-configmap.yaml
+	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-rules-configmap.yaml
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/pvc.yaml
 
 run: init-deploy

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Currently we don't have tests for the bot. It relies on manual tests:
   - and by changing the Makefile constants in `configs/<yourconfig>`
   - and the ConfigMap values in  `configs/<yourconfig>-configmap.yaml.
 
+* Create a rules config and a corresponding ConfigMap in [configs](configs),
+  - by copying [configs/example-rules-configmap.yaml](configs/example-rules-configmap.yaml),
+  - and by changing the Makefile constants in `configs/<yourconfig>`
+  - and the ConfigMap values in  `configs/<yourconfig>-rules-configmap.yaml.
+
 * Deploy the publishing bot by running make from the bot root directory, e.g.
 
 ```shell

--- a/artifacts/manifests/podspec.yaml
+++ b/artifacts/manifests/podspec.yaml
@@ -23,6 +23,7 @@ containers:
   - /publishing-bot
   - --alsologtostderr
   - --config=/etc/munge-config/config
+  - --rules-file=/etc/publisher-rules/config
   - --token-file=/etc/secret-volume/token
   - --interval=0
   - --healthz-port=8080
@@ -37,6 +38,8 @@ containers:
   volumeMounts:
   - mountPath: /etc/munge-config
     name: munge-config
+  - mountPath: /etc/publisher-rules
+    name: publisher-rules
   - mountPath: /etc/secret-volume
     name: secret-volume
   - mountPath: /netrc
@@ -49,6 +52,9 @@ volumes:
 - name: munge-config
   configMap:
     name: publisher-config
+- name: publisher-rules
+  configMap:
+    name: publisher-rules
 - name: secret-volume
   secret:
     secretName: github-token

--- a/cmd/publishing-bot/config/config.go
+++ b/cmd/publishing-bot/config/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// the file with the clear-text github token
 	TokenFile string `yaml:"token-file,omitempty"`
 
+	// the file that contain the repository rules
+	RulesFile string `yaml:"rules-file"`
+
 	// If true, don't make any mutating API calls
 	DryRun bool
 

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -16,7 +16,11 @@ type Dependency struct {
 }
 
 func (c Dependency) String() string {
-	return fmt.Sprintf("[repository %s, branch %s, subdir %s]", c.Repository, c.Branch, c.Dir)
+	repo := c.Repository
+	if len(repo) == 0 {
+		repo = "<source>"
+	}
+	return fmt.Sprintf("[repository %s, branch %s, subdir %s]", repo, c.Branch, c.Dir)
 }
 
 type BranchRule struct {

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+// Dependency of a piece of code
+type Dependency struct {
+	Repository string `yaml:"repository"`
+	Branch     string `yaml:"branch"`
+	// Dir from repo root
+	Dir string `yaml:"dir,omitempty"`
+}
+
+func (c Dependency) String() string {
+	return fmt.Sprintf("[repository %s, branch %s, subdir %s]", c.Repository, c.Branch, c.Dir)
+}
+
+type BranchRule struct {
+	Name string `yaml:"name"`
+	// k8s.io/* repos the branch rule depends on
+	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+	Source       Dependency   `yaml:"source"`
+}
+
+// a collection of publishing rules for a single destination repo
+type RepositoryRule struct {
+	DestinationRepository string       `yaml:"destination"`
+	Branches              []BranchRule `yaml:"branches"`
+	// if empty (e.g., for client-go), publisher will use its default publish script
+	PublishScript string `yaml:"publish-script"`
+	// not updated when true
+	Skip bool `yaml:"skipped,omitempty"`
+}
+
+type RepositoryRules struct {
+	SkippedSourceBranches []string         `yaml:"skip-source-branches"`
+	Rules                 []RepositoryRule `yaml:"rules"`
+}
+
+// LoadRules loads the repository rules either from the remote HTTP location or
+// a local file path.
+func LoadRules(config *Config) (*RepositoryRules, error) {
+	var (
+		content []byte
+		err     error
+	)
+	content, err = ioutil.ReadFile(config.RulesFile)
+	if err != nil {
+		return nil, err
+	}
+	var rules RepositoryRules
+	if err = yaml.Unmarshal(content, &rules); err != nil {
+		return nil, err
+	}
+	return &rules, nil
+}

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -46,6 +46,7 @@ func main() {
 	configFilePath := flag.String("config", "", "the config file in yaml format")
 	dryRun := flag.Bool("dry-run", false, "do not push anything to github")
 	tokenFile := flag.String("token-file", "", "the file with the github toke")
+	rulesFile := flag.String("rules-file", "", "the file with repository rules")
 	// TODO: make absolute
 	repoName := flag.String("source-repo", "", "the name of the source repository (eg. kubernetes)")
 	repoOrg := flag.String("source-org", "", "the name of the source repository organization, (eg. kubernetes)")
@@ -83,6 +84,9 @@ func main() {
 	if *tokenFile != "" {
 		cfg.TokenFile = *tokenFile
 	}
+	if *rulesFile != "" {
+		cfg.RulesFile = *rulesFile
+	}
 
 	if len(cfg.SourceRepo) == 0 || len(cfg.SourceOrg) == 0 {
 		glog.Fatalf("source-org and source-repo cannot be empty")
@@ -90,6 +94,10 @@ func main() {
 
 	if len(cfg.TargetOrg) == 0 {
 		glog.Fatalf("Target organization cannot be empty")
+	}
+
+	if len(cfg.RulesFile) == 0 {
+		glog.Fatalf("No rules file provided")
 	}
 
 	// start healthz server

--- a/configs/example-rules-configmap.yaml
+++ b/configs/example-rules-configmap.yaml
@@ -11,7 +11,6 @@ data:
       branches:
       name: <rule-name> # eg. "master"
       - source:
-          repository: <source-repository> # eg. "kubernetes"
           branch: <source-repository-branch> # eg. "master"
           dir: <subdirectory> # eg. "staging/src/k8s.io/client-go"
       publish-script: <script-path> # eg. /publish.sh

--- a/configs/example-rules-configmap.yaml
+++ b/configs/example-rules-configmap.yaml
@@ -1,0 +1,17 @@
+kind: ConfigMap
+metadata:
+  name: publisher-rules
+data:
+  config: |
+    # Specify branches you want to skip
+    skip-source-branches: 
+    # - release-1.7
+    rules:
+    - destination: <destination-repository-name> # eg. "client-go"
+      branches:
+      name: <rule-name> # eg. "master"
+      - source:
+          repository: <source-repository> # eg. "kubernetes"
+          branch: <source-repository-branch> # eg. "master"
+          dir: <subdirectory> # eg. "staging/src/k8s.io/client-go"
+      publish-script: <script-path> # eg. /publish.sh

--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -1,0 +1,467 @@
+kind: ConfigMap
+metadata:
+  name: publisher-rules
+data:
+  config: |
+    skip-source-branches: 
+    - release-1.5
+    - release-1.6
+    - release-1.7
+    rules:
+    - destination: apimachinery
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/apimachinery
+        name: master
+      - source:
+          repository: kubernetes
+          branch: release-1.6
+          dir: staging/src/k8s.io/apimachinery
+        name: release-1.6
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/apimachinery
+        name: release-1.7
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/apimachinery
+        name: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/apimachinery
+        name: relase-1.9
+      publish-script: /publish_scripts/publish_apimachinery.sh
+    - destination: api
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/api
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/api
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/api
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+      publish-script: /publish_scripts/publish_api.sh
+    - destination: client-go
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/client-go
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.5
+          dir: staging/src/k8s.io/client-go
+        name: release-2.0
+      - source:
+          repository: kubernetes
+          branch: release-1.6
+          dir: staging/src/k8s.io/client-go
+        name: release-3.0
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.6
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/client-go
+        name: release-4.0
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/client-go
+        name: release-5.0
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/client-go
+        name: release-6.0
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+      publish-script: /publish_scripts/publish_client_go.sh
+    - destination: apiserver
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/apiserver
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.6
+          dir: staging/src/k8s.io/apiserver
+        name: release-1.6
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.6
+        - repository: client-go
+          branch: release-3.0
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/apiserver
+        name: release-1.7
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+        - repository: client-go
+          branch: release-4.0
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/apiserver
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+        - repository: client-go
+          branch: release-5.0
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/apiserver
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+      publish-script: /publish_scripts/publish_apiserver.sh
+    - destination: kube-aggregator
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/kube-aggregator
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+        - repository: apiserver
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.6
+          dir: staging/src/k8s.io/kube-aggregator
+        name: release-1.6
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.6
+        - repository: client-go
+          branch: release-3.0
+        - repository: apiserver
+          branch: release-1.6
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/kube-aggregator
+        nane: release-1.7
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+        - repository: client-go
+          branch: release-4.0
+        - repository: apiserver
+          branch: release-1.7
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/kube-aggregator
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+        - repository: client-go
+          branch: release-5.0
+        - repository: apiserver
+          branch: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/kube-aggregator
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+        - repository: apiserver
+          branch: release-1.9
+      publish-script: /publish_scripts/publish_kube_aggregator.sh
+    - destination: sample-apiserver
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/sample-apiserver
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+        - repository: apiserver
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.6
+          dir: staging/src/k8s.io/sample-apiserver
+        name: release-1.6
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.6
+        - repository: client-go
+          branch: release-3.0
+        - repository: apiserver
+          branch: release-1.6
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/sample-apiserver
+        name: release-1.7
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+        - repository: client-go
+          branch: release-4.0
+        - repository: apiserver
+          branch: release-1.7
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/sample-apiserver
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+        - repository: client-go
+          branch: release-5.0
+        - repository: apiserver
+          branch: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/sample-apiserver
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+        - repository: apiserver
+          branch: release-1.9
+      publish-script: /publish_scripts/publish_sample_apiserver.sh
+    - destination: sample-controller
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/sample-controller
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/sample-controller
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+      publish-script: /publish_scripts/publish_sample_controller.sh
+    - destination: apiextensions-apiserver
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/apiextensions-apiserver
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+        - repository: apiserver
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/apiextensions-apiserver
+        name: release-1.7
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+        - repository: client-go
+          branch: release-4.0
+        - repository: apiserver
+          branch: release-1.7
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/apiextensions-apiserver
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+        - repository: client-go
+          branch: release-5.0
+        - repository: apiserver
+          branch: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/apiextensions-apiserver
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+        - repository: apiserver
+          branch: release-1.9
+      publish-script: /publish_scripts/publish_apiextensions_apiserver.sh
+    - destination: metrics
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/metrics
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master
+      - source:
+          repository: kubernetes
+          branch: release-1.7
+          dir: staging/src/k8s.io/metrics
+        name: release-1.7
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.7
+        - repository: client-go
+          branch: release-4.0
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/metrics
+        name: release-1.8
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.8
+        - repository: api
+          branch: release-1.8
+        - repository: client-go
+          branch: release-5.0
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/metrics
+        name: release-1.9
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.9
+        - repository: api
+          branch: release-1.9
+        - repository: client-go
+          branch: release-6.0
+      publish-script: /publish_scripts/publish_metrics.sh
+    - destination: code-generator
+      branches:
+      - source:
+          repository: kubernetes
+          branch: master
+          dir: staging/src/k8s.io/code-generator
+        name: master
+      - source:
+          repository: kubernetes
+          branch: release-1.8
+          dir: staging/src/k8s.io/code-generator
+        name: release-1.8
+      - source:
+          repository: kubernetes
+          branch: release-1.9
+          dir: staging/src/k8s.io/code-generator
+        name: release-1.9
+      publish-script: /publish_scripts/publish_code_generator.sh

--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -11,27 +11,22 @@ data:
     - destination: apimachinery
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/apimachinery
         name: master
       - source:
-          repository: kubernetes
           branch: release-1.6
           dir: staging/src/k8s.io/apimachinery
         name: release-1.6
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/apimachinery
         name: release-1.7
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/apimachinery
         name: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/apimachinery
         name: relase-1.9
@@ -39,7 +34,6 @@ data:
     - destination: api
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/api
         name: master
@@ -47,7 +41,6 @@ data:
         - repository: apimachinery
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/api
         name: release-1.8
@@ -55,7 +48,6 @@ data:
         - repository: apimachinery
           branch: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/api
         name: release-1.9
@@ -66,7 +58,6 @@ data:
     - destination: client-go
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/client-go
         name: master
@@ -76,12 +67,10 @@ data:
         - repository: api
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.5
           dir: staging/src/k8s.io/client-go
         name: release-2.0
       - source:
-          repository: kubernetes
           branch: release-1.6
           dir: staging/src/k8s.io/client-go
         name: release-3.0
@@ -89,7 +78,6 @@ data:
         - repository: apimachinery
           branch: release-1.6
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/client-go
         name: release-4.0
@@ -97,7 +85,6 @@ data:
         - repository: apimachinery
           branch: release-1.7
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/client-go
         name: release-5.0
@@ -107,7 +94,6 @@ data:
         - repository: api
           branch: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/client-go
         name: release-6.0
@@ -120,7 +106,6 @@ data:
     - destination: apiserver
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/apiserver
         name: master
@@ -132,7 +117,6 @@ data:
         - repository: client-go
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.6
           dir: staging/src/k8s.io/apiserver
         name: release-1.6
@@ -142,7 +126,6 @@ data:
         - repository: client-go
           branch: release-3.0
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/apiserver
         name: release-1.7
@@ -152,7 +135,6 @@ data:
         - repository: client-go
           branch: release-4.0
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/apiserver
         name: release-1.8
@@ -164,7 +146,6 @@ data:
         - repository: client-go
           branch: release-5.0
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/apiserver
         name: release-1.9
@@ -179,7 +160,6 @@ data:
     - destination: kube-aggregator
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/kube-aggregator
         name: master
@@ -193,7 +173,6 @@ data:
         - repository: apiserver
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.6
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.6
@@ -205,7 +184,6 @@ data:
         - repository: apiserver
           branch: release-1.6
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/kube-aggregator
         nane: release-1.7
@@ -217,7 +195,6 @@ data:
         - repository: apiserver
           branch: release-1.7
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.8
@@ -231,7 +208,6 @@ data:
         - repository: apiserver
           branch: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.9
@@ -248,7 +224,6 @@ data:
     - destination: sample-apiserver
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/sample-apiserver
         name: master
@@ -262,7 +237,6 @@ data:
         - repository: apiserver
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.6
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.6
@@ -274,7 +248,6 @@ data:
         - repository: apiserver
           branch: release-1.6
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.7
@@ -286,7 +259,6 @@ data:
         - repository: apiserver
           branch: release-1.7
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.8
@@ -300,7 +272,6 @@ data:
         - repository: apiserver
           branch: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.9
@@ -317,7 +288,6 @@ data:
     - destination: sample-controller
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/sample-controller
         name: master
@@ -329,7 +299,6 @@ data:
         - repository: client-go
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/sample-controller
         name: release-1.9
@@ -344,7 +313,6 @@ data:
     - destination: apiextensions-apiserver
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: master
@@ -358,7 +326,6 @@ data:
         - repository: apiserver
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.7
@@ -370,7 +337,6 @@ data:
         - repository: apiserver
           branch: release-1.7
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.8
@@ -384,7 +350,6 @@ data:
         - repository: apiserver
           branch: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.9
@@ -401,7 +366,6 @@ data:
     - destination: metrics
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/metrics
         name: master
@@ -413,7 +377,6 @@ data:
         - repository: client-go
           branch: master
       - source:
-          repository: kubernetes
           branch: release-1.7
           dir: staging/src/k8s.io/metrics
         name: release-1.7
@@ -423,7 +386,6 @@ data:
         - repository: client-go
           branch: release-4.0
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/metrics
         name: release-1.8
@@ -435,7 +397,6 @@ data:
         - repository: client-go
           branch: release-5.0
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/metrics
         name: release-1.9
@@ -450,17 +411,14 @@ data:
     - destination: code-generator
       branches:
       - source:
-          repository: kubernetes
           branch: master
           dir: staging/src/k8s.io/code-generator
         name: master
       - source:
-          repository: kubernetes
           branch: release-1.8
           dir: staging/src/k8s.io/code-generator
         name: release-1.8
       - source:
-          repository: kubernetes
           branch: release-1.9
           dir: staging/src/k8s.io/code-generator
         name: release-1.9


### PR DESCRIPTION
The second commit removes hard-coded Kubernetes rules and move them into a separate YAML file that has to be provided for the publishing-bot via `--rules-file` argument. This argument is required.
This can be either a local filesystem path or an URL form (for easier "fetch from repo directly ;)")...

Other changes:

* Moved the `SkippedSourceBranches` into the rules config
* Removed `./` defaulting for the destination directory

Original rules before this change are available under `cmd/publisher-bot/config/rules_example.yaml`.