### PR TITLE
With interval != 0 don't be fatal on Github API errors

### DIFF
--- a/artifacts/scripts/initialize_repos.sh
+++ b/artifacts/scripts/initialize_repos.sh
@@ -52,6 +52,7 @@ for repo in $(cd kubernetes/staging/src/k8s.io; ls -1); do
     if [ -d "${repo}" ]; then
 	pushd ${repo}
 	    git remote set-url origin "https://github.com/${ORG}/${repo}"
+	    rm -f .git/index.lock # in case git crashed before and left the lock file
 	popd
     else
 	git clone "https://github.com/${ORG}/${repo}"

--- a/cmd/publishing-bot/github.go
+++ b/cmd/publishing-bot/github.go
@@ -54,7 +54,7 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 	}
 
 	// create new newComment
-	body := fmt.Sprintf("The last publishing run failed: %v\n\n```%s```\n", e, logs)
+	body := fmt.Sprintf("The last publishing run failed: %v\n\n```%s```\n", e, tail(logs, 65000))
 	newComment, resp, err := client.Issues.CreateComment(ctx, org, repo, issue, &github.IssueComment{
 		Body: &body,
 	})
@@ -108,4 +108,51 @@ func CloseIssue(token, org, repo string, issue int) error {
 	}
 
 	return nil
+}
+
+// tail returns lines with a maximum of the given bytes in length. Only complete lines are
+// returned, with the exception if the is only one line, then "..." are put in front.
+// maxBytes must be at least 3.
+func tail(msg string, maxBytes int) string {
+	msg = strings.Trim(msg, "\n")
+	if len(msg) <= maxBytes {
+		return msg
+	}
+	lines := strings.Split(msg, "\n")
+	if len(lines) == 1 {
+		if len(lines[0]) <= maxBytes {
+			return lines[0]
+		}
+		return "..." + lines[0][max(0, len(lines[0])-maxBytes+3):]
+	}
+
+	prefix := "..."
+	ret := []string{}
+	n := len(prefix)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if n+len("\n")+len(lines[i]) > maxBytes {
+			if len(ret) == 0 {
+				return "..." + lines[0][max(0, len(lines[0])-maxBytes+3):]
+			}
+			break
+		}
+		ret = append(ret, lines[i])
+		n += len(lines[i]) + len("\n")
+	}
+
+	return strings.Join(reverse(append(ret, prefix)), "\n")
+}
+
+func reverse(s []string) []string {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+	return s
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/cmd/publishing-bot/github_test.go
+++ b/cmd/publishing-bot/github_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTail(t *testing.T) {
+	tests := []struct {
+		msg      string
+		maxBytes int
+		want     string
+	}{
+		{"", 10, ""},
+		{"012", 10, "012"},
+		{"0123456789", 10, "0123456789"},
+		{"01234567890", 10, "...4567890"},
+		{"\n01234567890", 10, "...4567890"},
+		{"01234567890\n", 10, "...4567890"},
+		{"01234\n0123", 10, "01234\n0123"},
+		{"0123456\n0123", 10, "...\n0123"},
+		{"0123\n0123\n0123", 10, "...\n0123"},
+		{"01\n01\n01\n01", 10, "...\n01\n01"},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			if got := tail(tt.msg, tt.maxBytes); got != tt.want {
+				t.Errorf("tail(%q, %d) = %v, want %v", tt.msg, tt.maxBytes, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -95,6 +95,11 @@ func main() {
 		}
 	}
 
+	githubIssueErrorf := glog.Fatalf
+	if *interval != 0 {
+		githubIssueErrorf = glog.Errorf
+	}
+
 	for {
 		last := time.Now()
 
@@ -118,10 +123,12 @@ func main() {
 				glog.Infof("Failed to run publisher: %v", err)
 				// TODO: support other orgs
 				if err := ReportOnIssue(err, logs, token, "kubernetes", cfg.SourceRepo, cfg.GithubIssue); err != nil {
-					glog.Fatalf("Failed to report logs on github issue: %v", err)
+					githubIssueErrorf("Failed to report logs on github issue: %v", err)
+					healthz.SetHealth(false, hash)
 				}
 			} else if err := CloseIssue(token, "kubernetes", cfg.SourceRepo, cfg.GithubIssue); err != nil {
-				glog.Fatalf("Failed to close issue: %v", err)
+				githubIssueErrorf("Failed to close issue: %v", err)
+				healthz.SetHealth(false, hash)
 			}
 		} else {
 			// run


### PR DESCRIPTION
If the github API returns error when updating the issue, this is not critical for the bot itself. We have other monitoring mechanism (healthz) in place.