### PR TITLE
Remove hardcoded kube

### DIFF
--- a/artifacts/scripts/publish_api.sh
+++ b/artifacts/scripts/publish_api.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "api" "${1}" "${2}" "${3}" "${4}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "api" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "true"

--- a/artifacts/scripts/publish_apiextensions_apiserver.sh
+++ b/artifacts/scripts/publish_apiextensions_apiserver.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "apiextensions-apiserver" "${1}" "${2}" "${3}" "${4}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "apiextensions-apiserver" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "false"

--- a/artifacts/scripts/publish_apimachinery.sh
+++ b/artifacts/scripts/publish_apimachinery.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "apimachinery" "${1}" "${2}" "${3}" "${4}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "apimachinery" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "true"

--- a/artifacts/scripts/publish_apiserver.sh
+++ b/artifacts/scripts/publish_apiserver.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "apiserver" "${1}" "${2}" "${3}" "${4}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "apiserver" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "true"

--- a/artifacts/scripts/publish_client_go.sh
+++ b/artifacts/scripts/publish_client_go.sh
@@ -35,13 +35,13 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "client-go" "${1}" "${2}" "${3}" "${4}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "client-go" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "true"
 
 if [ "$(git rev-parse origin/${2} || true)" != $(git rev-parse HEAD) ]; then
     godep restore

--- a/artifacts/scripts/publish_code_generator.sh
+++ b/artifacts/scripts/publish_code_generator.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "code-generator" "${1}" "${2}" "${3}" "${4}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "code-generator" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "false"

--- a/artifacts/scripts/publish_kube_aggregator.sh
+++ b/artifacts/scripts/publish_kube_aggregator.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "kube-aggregator" "${1}" "${2}" "${3}" "${4}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "kube-aggregator" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "false"

--- a/artifacts/scripts/publish_metrics.sh
+++ b/artifacts/scripts/publish_metrics.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "metrics" "${1}" "${2}" "${3}" "${4}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "metrics" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "true"

--- a/artifacts/scripts/publish_sample_apiserver.sh
+++ b/artifacts/scripts/publish_sample_apiserver.sh
@@ -34,13 +34,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "sample-apiserver" "${1}" "${2}" "${3}" "${4}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "sample-apiserver" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "false"
 
 if [ "$(git rev-parse origin/${2} || true)" != $(git rev-parse HEAD) ]; then
     # vendor/ should have all dependencies as a non-library

--- a/artifacts/scripts/publish_sample_controller.sh
+++ b/artifacts/scripts/publish_sample_controller.sh
@@ -34,13 +34,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 4 ]; then
-    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+if [ ! $# -eq 7 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote subdirectory source_repo_org source_repo_name" 
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "sample-controller" "${1}" "${2}" "${3}" "${4}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "sample-controller" "${1}" "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "false"
 
 if [ "$(git rev-parse origin/${2} || true)" != $(git rev-parse HEAD) ]; then
     # vendor/ should have all dependencies as a non-library

--- a/artifacts/scripts/publish_template.sh
+++ b/artifacts/scripts/publish_template.sh
@@ -37,8 +37,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [ ! $# -eq 6 ]; then
-    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos kubernetes_remote is_library"
+if [ ! $# -eq 9 ]; then
+    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos kubernetes_remote subdirectory source_repo_org source_repo_name is_library"
     exit 1
 fi
 
@@ -52,10 +52,16 @@ DST_BRANCH="${3:-master}"
 DEPS="${4}"
 # Remote url for Kubernetes. If empty, will fetch kubernetes
 # from https://github.com/kubernetes/kubernetes.
-KUBERNETES_REMOTE="${5}"
+SOURCE_REMOTE="${5}"
+# maps to staging/k8s.io/src/${REPO}
+SUBDIR="${6}"
+# source repository organization name (eg. kubernetes)
+SOURCE_REPO_ORG="${7}"
+# source repository name (eg. kubernetes) has to be set for the sync-tags
+SOURCE_REPO_NAME="${8}"
 # If ${REPO} is a library
-IS_LIBRARY="${6}"
-readonly SRC_BRANCH DST_BRANCH DEPS KUBERNETES_REMOTE IS_LIBRARY
+IS_LIBRARY="${9}"
+readonly SRC_BRANCH DST_BRANCH DEPS SOURCE_REMOTE SOURCE_REPO_ORG SOURCE_REPO_NAME SUBDIR IS_LIBRARY
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
@@ -82,13 +88,14 @@ fi
 
 # sync_repo cherry-picks the commits that change
 # k8s.io/kubernetes/staging/src/k8s.io/${REPO} to the ${DST_BRANCH}
-sync_repo "staging/src/k8s.io/${REPO}" "${SRC_BRANCH}" "${DST_BRANCH}" "${KUBERNETES_REMOTE}" "${DEPS}" "${IS_LIBRARY}"
+sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${SOURCE_REMOTE}" "${DEPS}" "${IS_LIBRARY}"
 
 # add tags
 EXTRA_ARGS=()
 PUSH_SCRIPT=../push-tags-${REPO}-${DST_BRANCH}.sh
 echo "#!/bin/bash" > ${PUSH_SCRIPT}
 chmod +x ${PUSH_SCRIPT}
-/sync-tags --upstream-remote upstream-kube --upstream-branch "${SRC_BRANCH}" \
+/sync-tags --source-org ${SOURCE_REPO_ORG} --source-repo ${SOURCE_REPO_NAME} \
+           --upstream-remote upstream --upstream-branch "${SRC_BRANCH}" \
            --push-script ${PUSH_SCRIPT} "${EXTRA_ARGS[@]-}" \
            -alsologtostderr

--- a/cmd/publishing-bot/config/config.go
+++ b/cmd/publishing-bot/config/config.go
@@ -21,9 +21,11 @@ type Config struct {
 	// the organization to publish into, e.g. k8s-publishing-bot or kubernetes-nightly
 	TargetOrg string `yaml:"target-org"`
 
-	// the source repo, e.g. "kubernetes"
-	// TODO: make this absolute
-	SourceRepo string `yaml:"source-repo,omitempty"`
+	// the source repo name, e.g. "kubernetes"
+	SourceRepo string `yaml:"source-repo"`
+
+	// the source repo org name, e.g. "kubernetes"
+	SourceOrg string `yaml:"source-org"`
 
 	// the file with the clear-text github token
 	TokenFile string `yaml:"token-file,omitempty"`

--- a/cmd/publishing-bot/healthz.go
+++ b/cmd/publishing-bot/healthz.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
+	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
 type Healthz struct {
@@ -31,6 +33,7 @@ type Healthz struct {
 
 	mutex    sync.RWMutex
 	response HealthResponse
+	config   config.Config
 }
 
 type HealthResponse struct {
@@ -78,7 +81,9 @@ func (h *Healthz) handler(w http.ResponseWriter, r *http.Request) {
 	h.mutex.RLock()
 	resp := h.response
 	if h.Issue != 0 {
-		resp.Issue = fmt.Sprintf("https://github.com/kubernetes/kubernetes/issues/%d", h.Issue)
+		// We chose target org so the issue can be opened in different org than
+		// a source repository.
+		resp.Issue = fmt.Sprintf("https://github.com/%s/%s/issues/%d", h.config.TargetOrg, h.config.SourceRepo, h.Issue)
 	}
 	h.mutex.RUnlock()
 

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -50,8 +50,7 @@ type branchRule struct {
 
 // a collection of publishing rules for a single destination repo
 type repoRules struct {
-	dstRepo string
-	// publisher.go has assumption that src.repo is always kubernetes.
+	dstRepo  string
 	srcToDst []branchRule
 	// if empty (e.g., for client-go), publisher will use its default publish script
 	publishScript string
@@ -65,27 +64,24 @@ type PublisherMunger struct {
 	config     *github.Config
 	// plog duplicates the logs at glog and a file
 	plog *plog
-	// absolute path to the k8s repos.
-	k8sIOPath string
+	// absolute path to the repos.
+	baseRepoPath string
 	// src branch names that are skipped
 	skippedSourceBranches []string
 }
 
 // New will create a new munger.
 func New(config *github.Config) (*PublisherMunger, error) {
-	// validate config
-	if config.SourceRepo != "kubernetes" {
-		// TODO: externalize the rules below to make it generic
-		return nil, fmt.Errorf("only kubernetes as source repo supported right now")
-	}
-	if config.TargetOrg == "" {
-		return nil, fmt.Errorf("target organization cannot be empty")
-	}
-
 	// create munger
 	p := &PublisherMunger{}
+
+	// set the baseRepoPath
 	gopath := os.Getenv("GOPATH")
-	p.k8sIOPath = filepath.Join(gopath, "src", "k8s.io")
+	// if the SourceRepo is not kubernetes, use github.com as baseRepoPath
+	p.baseRepoPath = filepath.Join(gopath, "src", "github.com", config.TargetOrg)
+	if config.SourceRepo == "kubernetes" {
+		p.baseRepoPath = filepath.Join(gopath, "src", "k8s.io")
+	}
 
 	clientGo := repoRules{
 		skipped: false,
@@ -543,22 +539,24 @@ func New(config *github.Config) (*PublisherMunger, error) {
 	return p, nil
 }
 
-// update the local checkout of k8s.io/kubernetes
-func (p *PublisherMunger) updateKubernetes() (string, error) {
+// update the local checkout of the source repository
+func (p *PublisherMunger) updateSourceRepo() (string, error) {
+	repoDir := filepath.Join(p.baseRepoPath, p.config.SourceRepo)
+
 	cmd := exec.Command("git", "fetch", "origin")
-	cmd.Dir = filepath.Join(p.k8sIOPath, "kubernetes")
+	cmd.Dir = repoDir
 	if err := p.plog.Run(cmd); err != nil {
 		return "", err
 	}
 
 	cmd = exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = filepath.Join(p.k8sIOPath, "kubernetes")
+	cmd.Dir = repoDir
 	hash, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed running %v on kube repo: %v", strings.Join(cmd.Args, " "), err)
+		return "", fmt.Errorf("failed running %v on %q repo: %v", strings.Join(cmd.Args, " "), p.config.SourceRepo, err)
 	}
 
-	// update kubernetes branches that are needed by other k8s.io repos.
+	// update source repo branches that are needed by other repos.
 	for _, repoRules := range p.reposRules {
 		for _, branchRule := range repoRules.srcToDst {
 			if p.skippedBranch(branchRule.src.branch) {
@@ -568,14 +566,14 @@ func (p *PublisherMunger) updateKubernetes() (string, error) {
 			src := branchRule.src
 			// we assume src.repo is always kubernetes
 			cmd := exec.Command("git", "branch", "-f", src.branch, fmt.Sprintf("origin/%s", src.branch))
-			cmd.Dir = filepath.Join(p.k8sIOPath, "kubernetes")
+			cmd.Dir = repoDir
 			if err := p.plog.Run(cmd); err == nil {
 				continue
 			}
 			// probably the error is because we cannot do `git branch -f` while
 			// current branch is src.branch, so try `git reset --hard` instead.
 			cmd = exec.Command("git", "reset", "--hard", fmt.Sprintf("origin/%s", src.branch))
-			cmd.Dir = filepath.Join(p.k8sIOPath, "kubernetes")
+			cmd.Dir = repoDir
 			if err := p.plog.Run(cmd); err != nil {
 				return "", err
 			}
@@ -609,14 +607,14 @@ func (p *PublisherMunger) ensureCloned(dst string, dstURL string) error {
 
 // constructs all the repos, but does not push the changes to remotes.
 func (p *PublisherMunger) construct() error {
-	kubernetesRemote := filepath.Join(p.k8sIOPath, "kubernetes", ".git")
+	sourceRemote := filepath.Join(p.baseRepoPath, p.config.SourceRepo, ".git")
 	for _, repoRules := range p.reposRules {
 		if repoRules.skipped {
 			continue
 		}
 
 		// clone the destination repo
-		dstDir := filepath.Join(p.k8sIOPath, repoRules.dstRepo, "")
+		dstDir := filepath.Join(p.baseRepoPath, repoRules.dstRepo, "")
 		dstURL := fmt.Sprintf("https://github.com/%s/%s.git", p.config.TargetOrg, repoRules.dstRepo)
 		if err := p.ensureCloned(dstDir, dstURL); err != nil {
 			p.plog.Errorf("%v", err)
@@ -646,8 +644,12 @@ func (p *PublisherMunger) construct() error {
 			if p.skippedBranch(branchRule.src.branch) {
 				continue
 			}
-
-			cmd := exec.Command(repoRules.publishScript, branchRule.src.branch, branchRule.dst.branch, formatDeps(branchRule.deps), kubernetesRemote)
+			if len(branchRule.src.dir) == 0 {
+				p.plog.Errorf("invalid branch rule %v: 'dir' cannot be empty", branchRule)
+				continue
+			}
+			// TODO: Refactor this to use environment variables instead
+			cmd := exec.Command(repoRules.publishScript, branchRule.src.branch, branchRule.dst.branch, formatDeps(branchRule.deps), sourceRemote, branchRule.src.dir, p.config.SourceOrg, p.config.SourceRepo)
 			if err := p.plog.Run(cmd); err != nil {
 				return err
 			}
@@ -676,7 +678,7 @@ func (p *PublisherMunger) publish() error {
 			continue
 		}
 
-		dstDir := filepath.Join(p.k8sIOPath, repoRules.dstRepo, "")
+		dstDir := filepath.Join(p.baseRepoPath, repoRules.dstRepo, "")
 		if err := os.Chdir(dstDir); err != nil {
 			return err
 		}
@@ -699,7 +701,7 @@ func (p *PublisherMunger) Run() (string, string, error) {
 	buf := bytes.NewBuffer(nil)
 	p.plog = NewPublisherLog(buf)
 
-	hash, err := p.updateKubernetes()
+	hash, err := p.updateSourceRepo()
 	if err != nil {
 		p.plog.Errorf("%v", err)
 		p.plog.Flush()

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -57,8 +57,16 @@ func main() {
 	publishBranch := flag.String("branch", "", "a (not qualified) branch name")
 	prefix := flag.String("prefix", "kubernetes-", "a string to put in front of upstream tags")
 	pushScriptPath := flag.String("push-script", "", "git-push command(s) are appended to this file to push the new tags to the origin remote")
+	// repository flags used when the repository is not k8s.io/kubernetes
+	repoName := flag.String("source-repo", "", "the name of the source repository (eg. kubernetes)")
+	repoOrg := flag.String("source-org", "", "the name of the source repository organization, (eg. kubernetes)")
+
 	flag.Usage = Usage
 	flag.Parse()
+
+	if len(*repoName) == 0 || len(*repoOrg) == 0 {
+		glog.Fatalf("source-org and source-repo cannot be empty")
+	}
 
 	if *upstreamRemote == "" {
 		glog.Fatalf("upstream-remote cannot be empty")
@@ -146,7 +154,7 @@ func main() {
 
 	// compute kube commit map
 	fmt.Printf("Computing mapping from kube commits to the local branch.\n")
-	kubeCommitsToDstCommits, err := git.KubeCommitsToDstCommits(r, bFirstParents, kFirstParents)
+	sourceCommitsToDstCommits, err := git.SourceCommitToDstCommits(r, *repoOrg, *repoName, bFirstParents, kFirstParents)
 	if err != nil {
 		glog.Fatalf("Failed to map upstream branch %s to HEAD: %v", *upstreamBranch, err)
 	}
@@ -178,7 +186,7 @@ func main() {
 		}
 
 		// map kube commit to local branch
-		bh, found := kubeCommitsToDstCommits[tag.Target]
+		bh, found := sourceCommitsToDstCommits[tag.Target]
 		if !found {
 			continue
 		}

--- a/configs/example-configmap.yaml
+++ b/configs/example-configmap.yaml
@@ -3,6 +3,9 @@ metadata:
   name: publisher-config
 data:
   config: |
+    # this specifies the source repository coordinates (org/name)
+    source-org: <source-github-org-or-user>
+    source-repo: <source-repository-name-in-your-org>
     # the github org or user to publish the new repos to
     target-org: <your-github-org-or-user>
 

--- a/configs/kubernetes-configmap.yaml
+++ b/configs/kubernetes-configmap.yaml
@@ -3,6 +3,8 @@ metadata:
   name: publisher-config
 data:
   config: |
+    source-org: kubernetes
+    source-repo: kubernetes
     target-org: kubernetes
     github-issue: 56876
     dry-run: false

--- a/configs/kubernetes-nightly-configmap.yaml
+++ b/configs/kubernetes-nightly-configmap.yaml
@@ -3,6 +3,8 @@ metadata:
   name: publisher-config
 data:
   config: |
+    source-org: kubernetes-nightly
+    source-repo: kubernetes
     target-org: kubernetes-nightly
     # github-issue: 56876
     dry-run: false

--- a/pkg/git/kube.go
+++ b/pkg/git/kube.go
@@ -17,23 +17,24 @@ limitations under the License.
 package git
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
-const (
-	KubernetesCommitPrefix         = "Kubernetes-commit: "
-	ancientSyncCommitSubjectPrefix = "sync(k8s.io/kubernetes)"
-)
-
-// kubeHash extracts kube commit from commit message
-func KubeHash(c *object.Commit) plumbing.Hash {
+// SourceHash extracts kube commit from commit message
+// The baseRepoName default to "kubernetes".
+// TODO: Refactor so we take the commitMsgTag as argument and don't need to
+// construct the ancientSyncCommitSubjectPrefix or sourceCommitPrefix
+func SourceHash(c *object.Commit, baseRepoOrg, baseRepoName string) plumbing.Hash {
 	lines := strings.Split(c.Message, "\n")
+	sourceCommitPrefix := strings.Title(baseRepoName) + "-commit: "
+	ancientSyncCommitSubjectPrefix := fmt.Sprintf("sync(%s/%s)", baseRepoOrg, baseRepoName)
 	for _, line := range lines {
-		if strings.HasPrefix(line, KubernetesCommitPrefix) {
-			return plumbing.NewHash(strings.TrimSpace(line[len(KubernetesCommitPrefix):]))
+		if strings.HasPrefix(line, sourceCommitPrefix) {
+			return plumbing.NewHash(strings.TrimSpace(line[len(sourceCommitPrefix):]))
 		}
 	}
 

--- a/pkg/git/mapping.go
+++ b/pkg/git/mapping.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
-// KubeCommitsToDstCommits returns a mapping from all kube mainline commits
+// SourceCommitToDstCommits returns a mapping from all kube mainline commits
 // to the corresponding dst commits after collapsing using "git filter-branch --sub-directory-filter":
 //
 // dst upstream
@@ -41,7 +41,7 @@ import (
 //       B
 //       A - initial commit
 //
-func KubeCommitsToDstCommits(r *gogit.Repository, dstFirstParents, kFirstParents []*object.Commit) (map[plumbing.Hash]plumbing.Hash, error) {
+func SourceCommitToDstCommits(r *gogit.Repository, repoOrg, repoName string, dstFirstParents, kFirstParents []*object.Commit) (map[plumbing.Hash]plumbing.Hash, error) {
 	// compute merge point table
 	kubeMergePoints, err := MergePoints(r, kFirstParents)
 	if err != nil {
@@ -52,7 +52,7 @@ func KubeCommitsToDstCommits(r *gogit.Repository, dstFirstParents, kFirstParents
 	directKubeHashToDstMainLineHash := map[plumbing.Hash]plumbing.Hash{}
 	for _, c := range dstFirstParents {
 		// kh might be a non-mainline-merge (because we had used branch commits as kube hashes long ago)
-		kh := KubeHash(c)
+		kh := SourceHash(c, repoOrg, repoName)
 		if kh == plumbing.ZeroHash {
 			continue
 		}


### PR DESCRIPTION
Reopened https://github.com/kubernetes/publishing-bot/pull/14 seems like GH screwed up or wrong rebase...

his pull attempts to remove all hardcoded kube variables which should allow to use the publisher bot for repositories other than kubernetes/kubernetes.
The defaulting should be preserved, so if SourceRepo is not specified it will default to "kubernetes", thus no changes in how the publisher bot is currently deployed are needed.