### PR TITLE
Allow fix-godeps to make commits empty

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -798,7 +798,7 @@ function update_full_godeps() {
     fi
 
     git add Godeps/Godeps.json
-    git add vendor/ || true
+    git add vendor/ --ignore-errors &>/dev/null || true
 
     # check if there are new contents
     if git-index-clean; then

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -668,7 +668,7 @@ function fix-godeps() {
     if ! git diff --exit-code ${dst_old_commit} &>/dev/null && [ "${squash}" = true ]; then
         echo "Amending last merge with godep changes."
         git reset --soft -q ${dst_old_commit}
-        git commit -q --amend -C ${dst_old_commit}
+        git commit -q --amend --allow-empty -C ${dst_old_commit}
     fi
 
     ensure-clean-working-dir


### PR DESCRIPTION
If a commit only included godep changes, fix-godeps might make it empty which is ok.

This happened yesterday due to a merge of the apiserver release-1.10 branch with master that had no changes other than godep for k8s.io/apiserver.