### PR TITLE
Replace non-existing clone flag --no-tags in git 2.1.4 with bash tag removal

### DIFF
--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -114,11 +114,16 @@ func (p *PublisherMunger) ensureCloned(dst string, dstURL string) error {
 		return nil
 	}
 
-	err := exec.Command("mkdir", "-p", dst).Run()
-	if err != nil {
+	cmd := exec.Command("mkdir", "-p", dst)
+	if err := p.plog.Run(cmd); err != nil {
 		return err
 	}
-	cmd := exec.Command("git", "clone", "--no-tags", dstURL, dst)
+	cmd = exec.Command("git", "clone", dstURL, dst)
+	if err := p.plog.Run(cmd); err != nil {
+		return err
+	}
+	cmd = exec.Command("/bin/bash", "-c", "git tag -l | xargs git tag -d")
+	cmd.Dir = dst
 	return p.plog.Run(cmd)
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/20144