### PR TITLE
Update to go 1.10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update \
  && apt-get install -y -qq git=1:2.1.4-2.1+deb8u5 \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates wget jq vim tmux bsdmainutils tig \
- && wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz \
- && tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz \
+ && wget https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz \
+ && tar -C /usr/local -xzf go1.10.2.linux-amd64.tar.gz \
  && rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH="/go-workspace"


### PR DESCRIPTION
The publishing bot is currently broken because `strings.Builder is undefined`: https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-408741947.

`strings.Builder` was introduced in Go 1.10. We use 1.10.2 in k/k (https://github.com/kubernetes/kubernetes/pull/63412, https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#external-dependencies).

This PR updates the go version to 1.10.2 for publishing bot so that it starts working again.