### PR TITLE
Disable publishing of 1.8 and older

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -19,10 +19,10 @@ data:
           branch: master
           dir: staging/src/k8s.io/code-generator
         name: master
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/code-generator
-        name: release-1.8
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/code-generator
+      #   name: release-1.8
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/code-generator
@@ -42,18 +42,18 @@ data:
           branch: master
           dir: staging/src/k8s.io/apimachinery
         name: master
-      - source:
-          branch: release-1.6
-          dir: staging/src/k8s.io/apimachinery
-        name: release-1.6
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/apimachinery
-        name: release-1.7
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/apimachinery
-        name: release-1.8
+      # - source:
+      #     branch: release-1.6
+      #     dir: staging/src/k8s.io/apimachinery
+      #   name: release-1.6
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/apimachinery
+      #   name: release-1.7
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/apimachinery
+      #   name: release-1.8
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/apimachinery
@@ -76,13 +76,13 @@ data:
         dependencies:
         - repository: apimachinery
           branch: master
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/api
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/api
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/api
@@ -116,33 +116,33 @@ data:
           branch: master
         - repository: api
           branch: master
-      - source:
-          branch: release-1.5
-          dir: staging/src/k8s.io/client-go
-        name: release-2.0
-      - source:
-          branch: release-1.6
-          dir: staging/src/k8s.io/client-go
-        name: release-3.0
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.6
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/client-go
-        name: release-4.0
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/client-go
-        name: release-5.0
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
+      # - source:
+      #     branch: release-1.5
+      #     dir: staging/src/k8s.io/client-go
+      #   name: release-2.0
+      # - source:
+      #     branch: release-1.6
+      #     dir: staging/src/k8s.io/client-go
+      #   name: release-3.0
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.6
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/client-go
+      #   name: release-4.0
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/client-go
+      #   name: release-5.0
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/client-go
@@ -188,35 +188,35 @@ data:
           branch: master
         - repository: client-go
           branch: master
-      - source:
-          branch: release-1.6
-          dir: staging/src/k8s.io/apiserver
-        name: release-1.6
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.6
-        - repository: client-go
-          branch: release-3.0
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/apiserver
-        name: release-1.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-        - repository: client-go
-          branch: release-4.0
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/apiserver
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
-        - repository: client-go
-          branch: release-5.0
+      # - source:
+      #     branch: release-1.6
+      #     dir: staging/src/k8s.io/apiserver
+      #   name: release-1.6
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.6
+      #   - repository: client-go
+      #     branch: release-3.0
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/apiserver
+      #   name: release-1.7
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      #   - repository: client-go
+      #     branch: release-4.0
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/apiserver
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
+      #   - repository: client-go
+      #     branch: release-5.0
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/apiserver
@@ -265,41 +265,41 @@ data:
           branch: master
         - repository: apiserver
           branch: master
-      - source:
-          branch: release-1.6
-          dir: staging/src/k8s.io/kube-aggregator
-        name: release-1.6
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.6
-        - repository: client-go
-          branch: release-3.0
-        - repository: apiserver
-          branch: release-1.6
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/kube-aggregator
-        name: release-1.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-        - repository: client-go
-          branch: release-4.0
-        - repository: apiserver
-          branch: release-1.7
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/kube-aggregator
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
-        - repository: client-go
-          branch: release-5.0
-        - repository: apiserver
-          branch: release-1.8
+      # - source:
+      #     branch: release-1.6
+      #     dir: staging/src/k8s.io/kube-aggregator
+      #   name: release-1.6
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.6
+      #   - repository: client-go
+      #     branch: release-3.0
+      #   - repository: apiserver
+      #     branch: release-1.6
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/kube-aggregator
+      #   name: release-1.7
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      #   - repository: client-go
+      #     branch: release-4.0
+      #   - repository: apiserver
+      #     branch: release-1.7
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/kube-aggregator
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
+      #   - repository: client-go
+      #     branch: release-5.0
+      #   - repository: apiserver
+      #     branch: release-1.8
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/kube-aggregator
@@ -358,45 +358,45 @@ data:
           branch: master
         required-packages:
         - k8s.io/code-generator
-      - source:
-          branch: release-1.6
-          dir: staging/src/k8s.io/sample-apiserver
-        name: release-1.6
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.6
-        - repository: client-go
-          branch: release-3.0
-        - repository: apiserver
-          branch: release-1.6
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/sample-apiserver
-        name: release-1.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-        - repository: client-go
-          branch: release-4.0
-        - repository: apiserver
-          branch: release-1.7
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/sample-apiserver
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
-        - repository: client-go
-          branch: release-5.0
-        - repository: apiserver
-          branch: release-1.8
-        - repository: code-generator
-          branch: release-1.8
-        required-packages:
-        - k8s.io/code-generator
+      # - source:
+      #     branch: release-1.6
+      #     dir: staging/src/k8s.io/sample-apiserver
+      #   name: release-1.6
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.6
+      #   - repository: client-go
+      #     branch: release-3.0
+      #   - repository: apiserver
+      #     branch: release-1.6
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/sample-apiserver
+      #   name: release-1.7
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      #   - repository: client-go
+      #     branch: release-4.0
+      #   - repository: apiserver
+      #     branch: release-1.7
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/sample-apiserver
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
+      #   - repository: client-go
+      #     branch: release-5.0
+      #   - repository: apiserver
+      #     branch: release-1.8
+      #   - repository: code-generator
+      #     branch: release-1.8
+      #   required-packages:
+      #   - k8s.io/code-generator
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/sample-apiserver
@@ -546,34 +546,34 @@ data:
           branch: master
         required-packages:
         - k8s.io/code-generator
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/apiextensions-apiserver
-        name: release-1.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-        - repository: client-go
-          branch: release-4.0
-        - repository: apiserver
-          branch: release-1.7
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/apiextensions-apiserver
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
-        - repository: client-go
-          branch: release-5.0
-        - repository: apiserver
-          branch: release-1.8
-        - repository: code-generator
-          branch: release-1.8
-        required-packages:
-        - k8s.io/code-generator
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/apiextensions-apiserver
+      #   name: release-1.7
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      #   - repository: client-go
+      #     branch: release-4.0
+      #   - repository: apiserver
+      #     branch: release-1.7
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/apiextensions-apiserver
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
+      #   - repository: client-go
+      #     branch: release-5.0
+      #   - repository: apiserver
+      #     branch: release-1.8
+      #   - repository: code-generator
+      #     branch: release-1.8
+      #   required-packages:
+      #   - k8s.io/code-generator
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/apiextensions-apiserver
@@ -639,26 +639,26 @@ data:
           branch: master
         - repository: client-go
           branch: master
-      - source:
-          branch: release-1.7
-          dir: staging/src/k8s.io/metrics
-        name: release-1.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.7
-        - repository: client-go
-          branch: release-4.0
-      - source:
-          branch: release-1.8
-          dir: staging/src/k8s.io/metrics
-        name: release-1.8
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.8
-        - repository: api
-          branch: release-1.8
-        - repository: client-go
-          branch: release-5.0
+      # - source:
+      #     branch: release-1.7
+      #     dir: staging/src/k8s.io/metrics
+      #   name: release-1.7
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.7
+      #   - repository: client-go
+      #     branch: release-4.0
+      # - source:
+      #     branch: release-1.8
+      #     dir: staging/src/k8s.io/metrics
+      #   name: release-1.8
+      #   dependencies:
+      #   - repository: apimachinery
+      #     branch: release-1.8
+      #   - repository: api
+      #     branch: release-1.8
+      #   - repository: client-go
+      #     branch: release-5.0
       - source:
           branch: release-1.9
           dir: staging/src/k8s.io/metrics


### PR DESCRIPTION
We don't support anything equal or older than 1.8. Go 1.10 is not compatible with v4.0.0 anymore, link errors.