### PR TITLE
Add branch rule go version value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,12 @@ MAINTAINER Chao Xu <xuchao@google.com>
 RUN apt-get update \
  && apt-get install -y -qq git=1:2.1.4-2.1+deb8u6 \
  && apt-get install -y -qq mercurial \
- && apt-get install -y -qq ca-certificates wget jq vim tmux bsdmainutils tig \
- && wget https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz \
- && tar -C /usr/local -xzf go1.10.2.linux-amd64.tar.gz \
+ && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig \
  && rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH="/go-workspace"
-ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+ENV GOROOT="/go-workspace/go"
+ENV PATH="${GOPATH}/bin:/go-workspace/go/bin:${PATH}"
 ENV GIT_COMMITTER_NAME="Kubernetes Publisher"
 ENV GIT_COMMITTER_EMAIL="k8s-publishing-bot@users.noreply.github.com"
 ENV TERM=xterm

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -44,6 +44,8 @@ func (c Source) String() string {
 
 type BranchRule struct {
 	Name string `yaml:"name"`
+	// a (full) version string like 1.10.2.
+	GoVersion string `yaml:"go"`
 	// k8s.io/* repos the branch rule depends on
 	Dependencies     []Dependency `yaml:"dependencies,omitempty"`
 	Source           Source       `yaml:"source"`

--- a/cmd/publishing-bot/publisher_test.go
+++ b/cmd/publishing-bot/publisher_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_updateEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		//{"no PATH", []string{"FOO=42"}, []string{"FOO=42", "PATH=/usr/local/go"}},
+		{"no PATH", []string{"FOO=42", "PATH=/bin", "BAR=1"}, []string{"FOO=42", "PATH=/usr/local/go:/bin", "BAR=1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updateEnv(tt.env, "PATH", prependPath("/usr/local/go"), "/usr/local/go"); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("updateEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -28,10 +28,12 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/code-generator
         name: release-1.9
+        go: 1.9.7
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/code-generator
         name: release-1.10
+        go: 1.9.7
       - source:
           branch: release-1.11
           dir: staging/src/k8s.io/code-generator
@@ -59,10 +61,12 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/apimachinery
         name: release-1.9
+        go: 1.9.7
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/apimachinery
         name: release-1.10
+        go: 1.9.7
       - source:
           branch: release-1.11
           dir: staging/src/k8s.io/apimachinery
@@ -88,6 +92,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/api
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -95,6 +100,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/api
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -148,6 +154,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/client-go
         name: release-6.0
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -157,6 +164,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/client-go
         name: release-7.0
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -222,6 +230,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/apiserver
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -233,6 +242,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/apiserver
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -305,6 +315,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -318,6 +329,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -402,6 +414,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -419,6 +432,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -478,6 +492,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/sample-controller
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -493,6 +508,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/sample-controller
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -579,6 +595,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -596,6 +613,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10
@@ -664,6 +682,7 @@ data:
           branch: release-1.9
           dir: staging/src/k8s.io/metrics
         name: release-1.9
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.9
@@ -675,6 +694,7 @@ data:
           branch: release-1.10
           dir: staging/src/k8s.io/metrics
         name: release-1.10
+        go: 1.9.7
         dependencies:
         - repository: apimachinery
           branch: release-1.10


### PR DESCRIPTION
Kube 1.9 and 1.10 need Go 1.9, especially because go vet was extended in Go 1.10. So we better make this configurable.