### PR TITLE
cmd/*: add github-host and package flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The robot is also responsible to update the `Godeps/Godeps.json` and the `vendor
 
 ### Publishing a new repo or a new branch
 
-* Adapt the rules in [config/kubernetes-rules-configmap.yaml](config/kubernetes-rules-configmap.yaml)
+* Adapt the rules in [config/kubernetes-rules-configmap.yaml](configs/kubernetes-rules-configmap.yaml)
 
 * For a new repo, add it to the repo list in [hack/fetch-all-latest-and-push.sh](hack/fetch-all-latest-and-push.sh)
 
@@ -28,7 +28,7 @@ Currently we don't have tests for the bot. It relies on manual tests:
 * Run [hack/fetch-all-latest-and-push.sh](hack/fetch-all-latest-and-push.sh) from the bot root directory to update the branches of your repos. This will sync your forks with upstream. **CAUTION:** this might delete data in your forks.
 
 * Create a config and a corresponding ConfigMap in [configs](configs),
-  - by copying [configs/example](config/example) and [configs/example-configmap.yaml](configs/example-configmap.yaml),
+  - by copying [configs/example](configs/example) and [configs/example-configmap.yaml](configs/example-configmap.yaml),
   - and by changing the Makefile constants in `configs/<yourconfig>`
   - and the ConfigMap values in  `configs/<yourconfig>-configmap.yaml`.
 

--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -37,8 +37,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [ ! $# -eq 11 ]; then
-    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name is_library"
+if [ ! $# -eq 12 ]; then
+    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name base_package is_library"
     exit 1
 fi
 
@@ -61,6 +61,8 @@ SUBDIR="${7}"
 SOURCE_REPO_ORG="${8}"
 # source repository name (eg. kubernetes) has to be set for the sync-tags
 SOURCE_REPO_NAME="${9}"
+# base package name (eg. k8s.io)
+BASE_PACKAGE="${10-k8s.io}"
 
 shift 9
 
@@ -69,7 +71,7 @@ IS_LIBRARY="${1}"
 # A ls-files pattern like "*/BUILD *.ext pkg/foo.go Makefile"
 RECURSIVE_DELETE_PATTERN="${2}"
 
-readonly SRC_BRANCH DST_BRANCH DEPS SOURCE_REMOTE SOURCE_REPO_ORG SOURCE_REPO_NAME SUBDIR IS_LIBRARY
+readonly SRC_BRANCH DST_BRANCH DEPS SOURCE_REMOTE SOURCE_REPO_ORG SOURCE_REPO_NAME BASE_PACKAGE SUBDIR IS_LIBRARY
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
@@ -96,7 +98,7 @@ fi
 
 # sync_repo cherry-picks the commits that change
 # k8s.io/kubernetes/staging/src/k8s.io/${REPO} to the ${DST_BRANCH}
-sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${SOURCE_REMOTE}" "${DEPS}" "${REQUIRED}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}"
+sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${SOURCE_REMOTE}" "${DEPS}" "${REQUIRED}" "${BASE_PACKAGE}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}"
 
 # add tags
 EXTRA_ARGS=()

--- a/cmd/publishing-bot/config/config.go
+++ b/cmd/publishing-bot/config/config.go
@@ -18,6 +18,15 @@ package config
 
 // Config is how we are configured to talk to github.
 type Config struct {
+	// GithubHost is the address for github.
+	// Defaults to github.com
+	GithubHost string `yaml:"github-host"`
+
+	// BasePackage is the base package name for this repo.
+	// Defaults to k8s.io when SourceOrg is kubernetes, otherwise, defaults
+	// to ${GithubHost}/${TargetOrg}
+	BasePackage string `yaml:"base-package"`
+
 	// the organization to publish into, e.g. k8s-publishing-bot or kubernetes-nightly
 	TargetOrg string `yaml:"target-org"`
 

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -137,7 +137,7 @@ func (p *PublisherMunger) construct() error {
 
 		// clone the destination repo
 		dstDir := filepath.Join(p.baseRepoPath, repoRule.DestinationRepository, "")
-		dstURL := fmt.Sprintf("https://github.com/%s/%s.git", p.config.TargetOrg, repoRule.DestinationRepository)
+		dstURL := fmt.Sprintf("https://%s/%s/%s.git", p.config.GithubHost, p.config.TargetOrg, repoRule.DestinationRepository)
 		if err := p.ensureCloned(dstDir, dstURL); err != nil {
 			p.plog.Errorf("%v", err)
 			return err
@@ -272,7 +272,7 @@ func (p *PublisherMunger) publish() error {
 				continue
 			}
 
-			cmd := exec.Command("/publish_scripts/push.sh", p.config.TokenFile, branchRule.Name)
+			cmd := exec.Command(p.config.BasePublishScriptPath+"/push.sh", p.config.TokenFile, branchRule.Name)
 			if err := p.plog.Run(cmd); err != nil {
 				return err
 			}

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -195,6 +195,7 @@ func (p *PublisherMunger) construct() error {
 				branchRule.Source.Dir,
 				p.config.SourceRepo,
 				p.config.SourceRepo,
+				p.config.BasePackage,
 				fmt.Sprintf("%v", repoRule.Library),
 				strings.Join(p.reposRules.RecursiveDeletePatterns, " "))
 			cmd.Env = append([]string(nil), branchEnv...) // make mutable

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -97,7 +97,7 @@ func (h *Server) healthzHandler(w http.ResponseWriter, r *http.Request) {
 	if h.Issue != 0 {
 		// We chose target org so the issue can be opened in different org than
 		// a source repository.
-		resp.Issue = fmt.Sprintf("https://github.com/%s/%s/issues/%d", h.config.TargetOrg, h.config.SourceRepo, h.Issue)
+		resp.Issue = fmt.Sprintf("https://%s/%s/%s/issues/%d", h.config.GithubHost, h.config.TargetOrg, h.config.SourceRepo, h.Issue)
 	}
 	h.mutex.RUnlock()
 


### PR DESCRIPTION
In case people are running github on-premise, they should be able
to tweak the github address.

the second case is: people might not be using the traditional name
convention like github.com/xxx/yyy as the package base, we should
allow them to specify the package name when cloning the code into
GOPATH.