### PR TITLE
Tighten log stdout/err order via lineWriter & syncWriter

### DIFF
--- a/cmd/publishing-bot/log_builder.go
+++ b/cmd/publishing-bot/log_builder.go
@@ -43,12 +43,12 @@ func NewLogBuilderWithMaxBytes(maxBytes int, rawLogs ...string) *logBuilder {
 	return logBuilder
 }
 
-func (builder *logBuilder) AddHeading(lines... string) *logBuilder {
+func (builder *logBuilder) AddHeading(lines ...string) *logBuilder {
 	builder.headings = append(builder.headings, lines...)
 	return builder
 }
 
-func (builder *logBuilder) AddTailing(lines... string) *logBuilder {
+func (builder *logBuilder) AddTailing(lines ...string) *logBuilder {
 	builder.tailings = append(builder.tailings, lines...)
 	return builder
 }

--- a/cmd/publishing-bot/publisher_logger_test.go
+++ b/cmd/publishing-bot/publisher_logger_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestLogLineWriter(t *testing.T) {
+
+	buf := new(bytes.Buffer)
+
+	var fakeLogWriter io.Writer
+	fakeLogWriter = newSyncWriter(muxWriter{buf})
+
+	content1 := "XXXXXXXXXXXXXX"
+	content2 := "YYYYYYYYYYYYYY"
+	content3 := "ZZZZZZZZZZZZZZ"
+
+	contents := []string{
+		content1, content2, content3,
+	}
+
+	wg := &sync.WaitGroup{}
+	for _, content := range contents {
+		w := newLineWriter(fakeLogWriter)
+		content := content
+		wg.Add(1)
+		go func() {
+			for i := 0; i < 99999; i++ {
+				w.Write([]byte(content + "\n"))
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	finalContent := buf.String()
+	uniqueLines := make(map[string]struct{})
+
+	NewLogBuilderWithMaxBytes(0, finalContent).
+		Trim("\n").
+		Split("\n").
+		Filter(func(line string) bool {
+			uniqueLines[line] = struct{}{}
+			return true
+		}).Log()
+
+	for line := range uniqueLines {
+		if line != content1 && line != content2 && line != content3 {
+			t.Errorf("malformed log: %s", line)
+			t.Fail()
+		}
+	}
+
+}


### PR DESCRIPTION
resolving bad format lines in logs:

```
	+ read dep branch
	+ jq '.Deps |= map(select(.ImportPath | (startswith("k8s.io/client-go/") or . == "k8s.io/client-go") | not))' Godeps/Godeps.json
	+ indent-godeps
	+ unexpand --first-only --tabs=2
	+ mv Godeps/Godeps.json.clean Godeps/Godeps.json
		R+u necho 'Running godep restore.'
	+ godepn restore
ing godep restore.
	+ checkout-deps-to-kube-commit Kubernetes-commit apimachinery:master,api:master
	+ local commit_msg_tag=Kubernetes-commit
	+ deps=()
```

`cmd.Stdout` and `cmd.Stderr` is writting logs per chars, which is the cause of bad outputting as above shown. so we use a `lineWriter` to buffer chars and flush them on `\n`. and a `syncWriter` will prevent dirty write into `bytes.Buffer` because it's not thread-safe.