### PR TITLE
init-repo: set Dir for go installation

### DIFF
--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -176,7 +176,9 @@ func installGoVersion(v string, pth string) {
 		glog.Fatal(err)
 	}
 	defer os.RemoveAll(tmpPath)
-	run(exec.Command("/bin/bash", "-c", fmt.Sprintf("curl -SLf https://storage.googleapis.com/golang/go%s.linux-amd64.tar.gz | tar -xz --strip 1 -C %s", v, tmpPath)))
+	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("curl -SLf https://storage.googleapis.com/golang/go%s.linux-amd64.tar.gz | tar -xz --strip 1 -C %s", v, tmpPath))
+	cmd.Dir = tmpPath
+	run(cmd)
 	if err := os.Rename(tmpPath, pth); err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
the cmd to install go version should setup a dir explictly, or it
would fail like `chdir /go-workspace/x: no such file or directory`.

1. `run` setup `Dir` to be `BaseRepoPath` if it is empty at https://github.com/kubernetes/publishing-bot/blob/master/cmd/init-repo/main.go#L255
1. the invocation of [installGoVersion](https://github.com/kubernetes/publishing-bot/blob/master/cmd/init-repo/main.go#L137) sits before the [mkdir of BaseRepoPath](https://github.com/kubernetes/publishing-bot/blob/master/cmd/init-repo/main.go#L145)