### PR TITLE
allow to skip tag synchronization

### DIFF
--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -65,6 +65,7 @@ type RepositoryRule struct {
 type RepositoryRules struct {
 	SkippedSourceBranches []string         `yaml:"skip-source-branches"`
 	SkipGodeps            bool             `yaml:"skip-godeps"`
+	SkipTags              bool             `yaml:"skip-tags"`
 	Rules                 []RepositoryRule `yaml:"rules"`
 
 	// ls-files patterns like: */BUILD *.ext pkg/foo.go Makefile

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -183,6 +183,12 @@ func (p *PublisherMunger) construct() error {
 				branchEnv = updateEnv(branchEnv, "PATH", prependPath(goBin), goBin)
 			}
 
+			skipTags := ""
+			if p.reposRules.SkipTags {
+				skipTags = "true"
+				p.plog.Infof("synchronizing tags is disabled")
+			}
+
 			// TODO: Refactor this to use environment variables instead
 			repoPublishScriptPath := filepath.Join(p.config.BasePublishScriptPath, "construct.sh")
 			cmd := exec.Command(repoPublishScriptPath,
@@ -197,7 +203,9 @@ func (p *PublisherMunger) construct() error {
 				p.config.SourceRepo,
 				p.config.BasePackage,
 				fmt.Sprintf("%v", repoRule.Library),
-				strings.Join(p.reposRules.RecursiveDeletePatterns, " "))
+				strings.Join(p.reposRules.RecursiveDeletePatterns, " "),
+				skipTags,
+			)
 			cmd.Env = append([]string(nil), branchEnv...) // make mutable
 			if p.reposRules.SkipGodeps {
 				cmd.Env = append(cmd.Env, "PUBLISHER_BOT_SKIP_GODEPS=true")


### PR DESCRIPTION
The `skip-tags: true` option in configuration will prevent the publisher bot from synchronizing the repository tags in case the tags are not required.