### PR TITLE
run git gc --auto before syncing repos

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -76,6 +76,8 @@ readonly SRC_BRANCH DST_BRANCH DEPS SOURCE_REMOTE SOURCE_REPO_ORG SOURCE_REPO_NA
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
 
+echo "Running garbage collection."
+git gc --auto
 echo "Fetching from origin."
 git fetch origin --no-tags
 echo "Cleaning up checkout."


### PR DESCRIPTION
Running `git gc --auto` should speed up the sync a little and keep the repository in clean state.