### PR TITLE
Add csi-api repo to publish bot

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -713,3 +713,17 @@ data:
           branch: release-1.11
         - repository: client-go
           branch: release-8.0
+    - destination: csi-api
+      library: true
+      branches:
+      - source:
+          branch: master
+          dir: staging/src/k8s.io/csi-api
+        name: master
+        dependencies:
+        - repository: apimachinery
+          branch: master
+        - repository: api
+          branch: master
+        - repository: client-go
+          branch: master

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -43,6 +43,7 @@ repos=(
     apiextensions-apiserver
     metrics
     code-generator
+    csi-api
 )
 
 repo_count=${#repos[@]}


### PR DESCRIPTION
We have a new https://github.com/kubernetes/csi-api repo that should be populated from https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/csi-api

I would like to turn on auto publishing.

/assign @sttts 