### PR TITLE
Delete new Godeps file not on the branch

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -864,6 +864,7 @@ function update_full_godeps() {
     fi
 
     git add Godeps/Godeps.json
+    git clean -f Godeps # clean possible new files missing in branch (e.g. README)
     git add vendor/ --ignore-errors &>/dev/null || true
 
     # check if there are new contents


### PR DESCRIPTION
In the kube-proxy staging dir the Godeps/README was forgotten originally and added in a later PR. But our godep run in the bot creates it and we left it in the working dir, making the cherry-pick which adds the file fail.