### PR TITLE
Fix branch-name-hash map to be used on publish

### DIFF
--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -101,7 +101,7 @@ func (p *PublisherMunger) updateSourceRepo() (map[string]plumbing.Hash, error) {
 			return fmt.Errorf("failed to create reference %s pointing to %s", localBranch.Name(), localBranch.Hash().String())
 		}
 
-		heads[localBranch.Name().String()] = localBranch.Hash()
+		heads[shortName] = localBranch.Hash()
 
 		return nil
 	}); err != nil {


### PR DESCRIPTION
We switch to refs/heads/branch like branch names in https://github.com/kubernetes/publishing-bot/pull/106, but forgot to use the short name as key for the branch name hash map.