### PR TITLE
Add apiextensions as a dependency to csi-api

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -835,6 +835,8 @@ data:
           branch: master
         - repository: client-go
           branch: master
+        - repository: apiextensions-apiserver
+          branch: master
       - source:
           branch: release-1.12
           dir: staging/src/k8s.io/csi-api
@@ -846,6 +848,8 @@ data:
           branch: release-1.12
         - repository: client-go
           branch: release-9.0
+        - repository: apiextensions-apiserver
+          branch: release-1.12
     - destination: cli-runtime
       library: true
       branches:


### PR DESCRIPTION
publishing-bot is currently broken: https://github.com/kubernetes/kubernetes/issues/56876

https://github.com/kubernetes/kubernetes/pull/68579 added apiextensions-apiserver as a dependency to csi-api but it is not listed as a dependency here, which breaks publishing-bot while reconstructing godeps.json.

This is the relevant part of the error log:

```sh
++ git commit-tree -p 2966180a4e54fab57c98153a33cf018cc4017ba3 -p HEAD -m 'Merge pull request #68579 from verult/adc-crd-access

    	Updating CSI e2e test to create CSI CRDs

...

+ update_full_godeps apimachinery:master,api:master,client-go:master k8s.io true Kubernetes-commit
    	+ local deps=apimachinery:master,api:master,client-go:master
    	+ local base_package=k8s.io
    	+ local is_library=true
    	+ local commit_msg_tag=Kubernetes-commit
    	+ ensure-clean-working-dir
    	+ git diff HEAD --exit-code
    	+ for d in '$../*'
    	+ '[' '!' -d '$../*' ']'
    	+ continue
    	+ '[' '!' -f Godeps/Godeps.json ']'
    	+ echo 'Removing k8s.io/* dependencies from Godeps.json'
    	+ local dep=
    	+ local branch=
    	+ local depbranch=
    	++ basename /go-workspace/src/k8s.io/csi-api
    	+ for depbranch in '${deps//,/ }' '$(basename "${PWD}")'
    	+ IFS=:
    	+ read dep branch
    	+ jq '.Deps |= map(select(.ImportPath | (startswith("k8s.io/apimachinery/") or . == "k8s.io/apimachinery") | not))' Godeps/Godeps.json
    	+ indent-godeps
    	+ unexpand --first-only --tabs=2
    	+ mv Godeps/Godeps.json.clean Godeps/Godeps.json
    	+ for depbranch in '${deps//,/ }' '$(basename "${PWD}")'
    	+ IFS=:
    	+ read dep branch
    	+ jq '.Deps |= map(select(.ImportPath | (startswith("k8s.io/api/") or . == "k8s.io/api") | not))' Godeps/Godeps.json
    	+ indent-godeps
    	+ unexpand --first-only --tabs=2
    	+ mv Godeps/Godeps.json.clean Godeps/Godeps.json
    	+ for depbranch in '${deps//,/ }' '$(basename "${PWD}")'
    	+ IFS=:
    	+ read dep branch
    	+ jq '.Deps |= map(select(.ImportPath | (startswith("k8s.io/client-go/") or . == "k8s.io/client-go") | not))' Godeps/Godeps.json
    	+ indent-godeps
    	+ unexpand --first-only --tabs=2
    	+ mv Godeps/Godeps.json.clean Godeps/Godeps.json
    	+ for depbranch in '${deps//,/ }' '$(basename "${PWD}")'
    	+ IFS=:
    	+ read dep branch
    	+ jq '.Deps |= map(select(.ImportPath | (startswith("k8s.io/csi-api/") or . == "k8s.io/csi-api") | not))' Godeps/Godeps.json
    	+ indent-godeps
    	+ unexpand --first-only --tabs=2
    	+ mv Godeps/Godeps.json.clean Godeps/Godeps.json
    	+ echo 'Running godep restore.'
    	+ godep restore
    	# cd /go-workspace/src/k8s.io/apiextensions-apiserver; git checkout xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    	error: pathspec 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' did not match any file(s) known to git.
    	godep: error restoring dep (k8s.io/apiextensions-apiserver/pkg/apis/apiextensions): exit status 1
    	# cd /go-workspace/src/k8s.io/apiextensions-apiserver; git checkout xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    	error: pathspec 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' did not match any file(s) known to git.
    	godep: error restoring dep (k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1): exit status 1
    	# cd /go-workspace/src/k8s.io/apiextensions-apiserver; git checkout xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    	error: pathspec 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' did not match any file(s) known to git.
    	godep: error restoring dep (k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme): exit status 1
    	godep: Error restoring some deps. Aborting check.

[21 Sep 18 11:02 UTC]: exit status 1```
```



