### PR TITLE
Revert "added bootstrap repo."

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -984,15 +984,3 @@ data:
           branch: release-1.12
         - repository: apiserver
           branch: release-1.12
-    - destination: cluster-bootstrap
-      library: true
-      branches:
-      - source:
-          branch: master
-          dir: staging/src/k8s.io/cluster-bootstrap
-        name: master
-        dependencies:
-        - repository: apimachinery
-          branch: master
-        - repository: api
-          branch: master

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -50,7 +50,6 @@ repos=(
     kubelet
     kube-scheduler
     kube-controller-manager
-    cluster-bootstrap
 )
 
 repo_count=${#repos[@]}


### PR DESCRIPTION
Reverts kubernetes/publishing-bot#89

The target repository is not ready. It has to be empty. And the publishing-bot needs permissions, compare https://github.com/kubernetes/org/issues/56#issue-356711512.

