### PR TITLE
Bump default go version to 1.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 go:
-  - 1.9.x
+  - 1.11.1
 go_import_path: k8s.io/publishing-bot

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -19,7 +19,7 @@ import (
 const (
 	depCommit        = "7c44971bbb9f0ed87db40b601f2d9fe4dffb750d"
 	godepCommit      = "tags/v80"
-	DefaultGoVersion = "1.10.2"
+	DefaultGoVersion = "1.11.1"
 )
 
 var (

--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -38,10 +38,12 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/code-generator
         name: release-1.11
+        go: 1.10.2
       - source:
           branch: release-1.12
           dir: staging/src/k8s.io/code-generator
         name: release-1.12
+        go: 1.10.4
     - destination: apimachinery
       library: true
       branches:
@@ -75,10 +77,12 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/apimachinery
         name: release-1.11
+        go: 1.10.2
       - source:
           branch: release-1.12
           dir: staging/src/k8s.io/apimachinery
         name: release-1.12
+        go: 1.10.4
     - destination: api
       library: true
       branches:
@@ -116,6 +120,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/api
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -123,6 +128,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/api
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -189,6 +195,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/client-go
         name: release-8.0
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -198,6 +205,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/client-go
         name: release-9.0
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -278,6 +286,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/apiserver
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -289,6 +298,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/apiserver
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -378,6 +388,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -391,6 +402,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/kube-aggregator
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -498,6 +510,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -515,6 +528,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/sample-apiserver
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -589,6 +603,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/sample-controller
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -604,6 +619,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/sample-controller
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -711,6 +727,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -728,6 +745,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/apiextensions-apiserver
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -803,6 +821,7 @@ data:
           branch: release-1.11
           dir: staging/src/k8s.io/metrics
         name: release-1.11
+        go: 1.10.2
         dependencies:
         - repository: apimachinery
           branch: release-1.11
@@ -814,6 +833,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/metrics
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -841,6 +861,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/csi-api
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -868,6 +889,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/cli-runtime
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: api
           branch: release-1.12
@@ -895,6 +917,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/sample-cli-plugin
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: api
           branch: release-1.12
@@ -918,6 +941,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/kube-proxy
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -937,6 +961,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/kubelet
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -958,6 +983,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/kube-scheduler
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12
@@ -979,6 +1005,7 @@ data:
           branch: release-1.12
           dir: staging/src/k8s.io/kube-controller-manager
         name: release-1.12
+        go: 1.10.4
         dependencies:
         - repository: apimachinery
           branch: release-1.12


### PR DESCRIPTION
Also update the go versions of:

- v1.11 branch to 1.10.2
- v1.12 branch to 1.10.4

Ref:

- v1.11 used go version 1.10.2: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md#external-dependencies
- v1.12 used go version 1.10.4: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md#external-dependencies
- Bump of go version from 1.10.4 to 1.11.1 on k/k master: https://github.com/kubernetes/kubernetes/pull/69386
