### PR TITLE
Handle degenerated non-mainline merge

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -518,6 +518,7 @@ sync_repo() {
 function pick-merge-as-single-commit() {
     grep -F -q -x "$1" <<EOF
 25ebf875b4235cb8f43be2aec699d62e78339cec
+8014d73345233c773891f26008e55dc3b5232c7c
 EOF
 }
 


### PR DESCRIPTION
Handling merges on feature branches is tricky, especially when the feature branch
is degenerated to single commits on the filtered mainline. Here were add such a
merge commit that is very seldom as non-overlapping feature branches with
intermediate master merges do not happen often.

The respective merge is from https://github.com/kubernetes/kubernetes/pull/69946.