### PR TITLE
Handle degenerated non-mainline merge - part 2

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -519,6 +519,7 @@ function pick-merge-as-single-commit() {
     grep -F -q -x "$1" <<EOF
 25ebf875b4235cb8f43be2aec699d62e78339cec
 8014d73345233c773891f26008e55dc3b5232c7c
+536cee71b4dcb74fa7c80fdd6a709cdbf970e4a2
 EOF
 }
 


### PR DESCRIPTION
Handling merges on feature branches is tricky, especially when the feature branch
is degenerated to single commits on the filtered mainline. Here were add such a
merge commit that is very seldom as non-overlapping feature branches with
intermediate master merges do not happen often.

The respective merge is from https://github.com/kubernetes/kubernetes/pull/69946.