### PR TITLE
Override end-of-line attributes in gitattributes files

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -80,6 +80,8 @@ readonly REPO SRC_BRANCH DST_BRANCH DEPS REQUIRED SOURCE_REMOTE SOURCE_REPO_ORG 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
 
+echo "Creating .git/info/attributes file to override .gitattributes files."
+echo "* -text" > .git/info/attributes
 echo "Running garbage collection."
 git gc --auto
 echo "Fetching from origin."


### PR DESCRIPTION
If a repo contains `.gitattributes` files and contains special attributes for line endings, they are not respected while fetching using go-git  because it doesn't support `.gitattributes`. So default configuration values are followed. This leads to a dirty workspace.

To avoid this, we need to instruct git to not attempt any line ending conversions. The only way to override the config in `.gitattributes` files is through a `.git/info/attributes` file

This PR adds such a file and prevents any end-of-line conversions.

---

Ref: https://git-scm.com/docs/gitattributes

> When deciding what attributes are assigned to a path, Git consults $GIT_DIR/info/attributes file (which has the highest precedence), .gitattributes file in the same directory as the path in question, and its parent directories up to the toplevel of the work tree (the further the directory that contains .gitattributes is from the path in question, the lower its precedence). Finally global and system-wide files are considered (they have the lowest precedence).

---

I also double checked that this works in k/k:

1. Added `* text eol=lf` in `.gitattributes`.
2. `git add --renormalize .` and then `git status` shows a lot of files changed.
3. `echo "* -text" > .git/info/attributes` and then `git add --renormalize .` removes all those changes
4. `rm .git/info/attributes && git add --renormalize .` adds them back



