### PR TITLE
Add 1.13 branches and disable publishing of 1.9

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -24,11 +24,11 @@ data:
       #     branch: release-1.8
       #     dir: staging/src/k8s.io/code-generator
       #   name: release-1.8
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/code-generator
-        name: release-1.9
-        go: 1.9.7
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/code-generator
+      #  name: release-1.9
+      #  go: 1.9.7
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/code-generator
@@ -44,6 +44,11 @@ data:
           dir: staging/src/k8s.io/code-generator
         name: release-1.12
         go: 1.10.4
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/code-generator
+        name: release-1.13
+        go: 1.11.2
     - destination: apimachinery
       library: true
       branches:
@@ -63,11 +68,11 @@ data:
       #     branch: release-1.8
       #     dir: staging/src/k8s.io/apimachinery
       #   name: release-1.8
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/apimachinery
-        name: release-1.9
-        go: 1.9.7
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/apimachinery
+      #  name: release-1.9
+      #  go: 1.9.7
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/apimachinery
@@ -83,6 +88,11 @@ data:
           dir: staging/src/k8s.io/apimachinery
         name: release-1.12
         go: 1.10.4
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/apimachinery
+        name: release-1.13
+        go: 1.11.2
     - destination: api
       library: true
       branches:
@@ -100,14 +110,14 @@ data:
       #   dependencies:
       #   - repository: apimachinery
       #     branch: release-1.8
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/api
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/api
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/api
@@ -132,6 +142,14 @@ data:
         dependencies:
         - repository: apimachinery
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/api
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
     - destination: client-go
       library: true
       branches:
@@ -171,16 +189,16 @@ data:
       #     branch: release-1.8
       #   - repository: api
       #     branch: release-1.8
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/client-go
-        name: release-6.0
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
+      # - source:
+      #   branch: release-1.9
+      #    dir: staging/src/k8s.io/client-go
+      #  name: release-6.0
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/client-go
@@ -211,6 +229,16 @@ data:
           branch: release-1.12
         - repository: api
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/client-go
+        name: release-10.0
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
       smoke-test: |
         godep restore
         go build ./...
@@ -258,18 +286,18 @@ data:
       #     branch: release-1.8
       #   - repository: client-go
       #     branch: release-5.0
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/apiserver
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/apiserver
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/apiserver
@@ -306,6 +334,18 @@ data:
           branch: release-1.12
         - repository: client-go
           branch: release-9.0
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/apiserver
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
     - destination: kube-aggregator
       branches:
       - source:
@@ -356,20 +396,20 @@ data:
       #     branch: release-5.0
       #   - repository: apiserver
       #     branch: release-1.8
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/kube-aggregator
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
-        - repository: apiserver
-          branch: release-1.9
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/kube-aggregator
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
+      #  - repository: apiserver
+      #    branch: release-1.9
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/kube-aggregator
@@ -412,6 +452,20 @@ data:
           branch: release-9.0
         - repository: apiserver
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/kube-aggregator
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
+        - repository: apiserver
+          branch: release-1.13
     - destination: sample-apiserver
       branches:
       - source:
@@ -470,24 +524,24 @@ data:
       #     branch: release-1.8
       #   required-packages:
       #   - k8s.io/code-generator
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/sample-apiserver
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
-        - repository: apiserver
-          branch: release-1.9
-        - repository: code-generator
-          branch: release-1.9
-        required-packages:
-        - k8s.io/code-generator
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/sample-apiserver
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
+      #  - repository: apiserver
+      #    branch: release-1.9
+      #  - repository: code-generator
+      #    branch: release-1.9
+      #  required-packages:
+      #  - k8s.io/code-generator
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/sample-apiserver
@@ -540,6 +594,24 @@ data:
           branch: release-1.12
         - repository: code-generator
           branch: release-1.12
+        required-packages:
+        - k8s.io/code-generator
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/sample-apiserver
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
+        - repository: apiserver
+          branch: release-1.13
+        - repository: code-generator
+          branch: release-1.13
         required-packages:
         - k8s.io/code-generator
       smoke-test: |
@@ -567,22 +639,22 @@ data:
           branch: master
         required-packages:
         - k8s.io/code-generator
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/sample-controller
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
-        - repository: code-generator
-          branch: release-1.9
-        required-packages:
-        - k8s.io/code-generator
+      # - source:
+      #   branch: release-1.9
+      #    dir: staging/src/k8s.io/sample-controller
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
+      #  - repository: code-generator
+      #    branch: release-1.9
+      #  required-packages:
+      #  - k8s.io/code-generator
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/sample-controller
@@ -629,6 +701,22 @@ data:
           branch: release-9.0
         - repository: code-generator
           branch: release-1.12
+        required-packages:
+        - k8s.io/code-generator
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/sample-controller
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
+        - repository: code-generator
+          branch: release-1.13
         required-packages:
         - k8s.io/code-generator
       smoke-test: |
@@ -687,24 +775,24 @@ data:
       #     branch: release-1.8
       #   required-packages:
       #   - k8s.io/code-generator
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/apiextensions-apiserver
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
-        - repository: apiserver
-          branch: release-1.9
-        - repository: code-generator
-          branch: release-1.9
-        required-packages:
-        - k8s.io/code-generator
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/apiextensions-apiserver
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
+      #  - repository: apiserver
+      #    branch: release-1.9
+      #  - repository: code-generator
+      #    branch: release-1.9
+      #  required-packages:
+      #  - k8s.io/code-generator
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/apiextensions-apiserver
@@ -757,6 +845,24 @@ data:
           branch: release-1.12
         - repository: code-generator
           branch: release-1.12
+        required-packages:
+        - k8s.io/code-generator
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/apiextensions-apiserver
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
+        - repository: apiserver
+          branch: release-1.13
+        - repository: code-generator
+          branch: release-1.13
         required-packages:
         - k8s.io/code-generator
     - destination: metrics
@@ -793,18 +899,18 @@ data:
       #     branch: release-1.8
       #   - repository: client-go
       #     branch: release-5.0
-      - source:
-          branch: release-1.9
-          dir: staging/src/k8s.io/metrics
-        name: release-1.9
-        go: 1.9.7
-        dependencies:
-        - repository: apimachinery
-          branch: release-1.9
-        - repository: api
-          branch: release-1.9
-        - repository: client-go
-          branch: release-6.0
+      # - source:
+      #    branch: release-1.9
+      #    dir: staging/src/k8s.io/metrics
+      #  name: release-1.9
+      #  go: 1.9.7
+      #  dependencies:
+      #  - repository: apimachinery
+      #    branch: release-1.9
+      #  - repository: api
+      #    branch: release-1.9
+      #  - repository: client-go
+      #    branch: release-6.0
       - source:
           branch: release-1.10
           dir: staging/src/k8s.io/metrics
@@ -841,6 +947,18 @@ data:
           branch: release-1.12
         - repository: client-go
           branch: release-9.0
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/metrics
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
     - destination: csi-api
       library: true
       branches:
@@ -871,6 +989,20 @@ data:
           branch: release-9.0
         - repository: apiextensions-apiserver
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/csi-api
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
+        - repository: apiextensions-apiserver
+          branch: release-1.13
     - destination: cli-runtime
       library: true
       branches:
@@ -897,6 +1029,18 @@ data:
           branch: release-1.12
         - repository: client-go
           branch: release-9.0
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/cli-runtime
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: api
+          branch: release-1.13
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
     - destination: sample-cli-plugin
       library: false
       branches:
@@ -927,6 +1071,20 @@ data:
           branch: release-1.12
         - repository: client-go
           branch: release-9.0
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/sample-cli-plugin
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: api
+          branch: release-1.13
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: cli-runtime
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0
     - destination: kube-proxy
       library: true
       branches:
@@ -945,6 +1103,14 @@ data:
         dependencies:
         - repository: apimachinery
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/kube-proxy
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
     - destination: kubelet
       library: true
       branches:
@@ -967,6 +1133,16 @@ data:
           branch: release-1.12
         - repository: api
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/kubelet
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
     - destination: kube-scheduler
       library: true
       branches:
@@ -989,6 +1165,16 @@ data:
           branch: release-1.12
         - repository: apiserver
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/kube-scheduler
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: apiserver
+          branch: release-1.13
     - destination: kube-controller-manager
       library: true
       branches:
@@ -1011,6 +1197,16 @@ data:
           branch: release-1.12
         - repository: apiserver
           branch: release-1.12
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/kube-controller-manager
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: apiserver
+          branch: release-1.13
     - destination: cluster-bootstrap
       library: true
       branches:
@@ -1023,6 +1219,16 @@ data:
           branch: master
         - repository: api
           branch: master
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/cluster-bootstrap
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: api
+          branch: release-1.13
     - destination: cloud-provider
       library: true
       branches:
@@ -1037,3 +1243,15 @@ data:
           branch: master
         - repository: client-go
           branch: master
+      - source:
+          branch: release-1.13
+          dir: staging/src/k8s.io/cloud-provider
+        name: release-1.13
+        go: 1.11.2
+        dependencies:
+        - repository: api
+          branch: release-1.13
+        - repository: apimachinery
+          branch: release-1.13
+        - repository: client-go
+          branch: release-10.0


### PR DESCRIPTION
Ref: https://groups.google.com/d/topic/kubernetes-dev/8D_ea0xw3BQ/discussion

1.13 branch has been created in k/k and with that we stop supporting 1.9 and older.

/assign @sttts 