### PR TITLE
report more useful data via healthz endpoint

### DIFF
--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -175,17 +175,17 @@ func main() {
 			token := strings.Trim(string(bs), " \t\n")
 
 			// run
-			logs, hash, err := publisher.Run()
-			server.SetHealth(err == nil, hash)
+			logs, healthz, err := publisher.Run()
+			server.SetHealth(err == nil, healthz)
 			if err != nil {
 				glog.Infof("Failed to run publisher: %v", err)
 				if err := ReportOnIssue(err, logs, token, cfg.TargetOrg, cfg.SourceRepo, cfg.GithubIssue); err != nil {
 					githubIssueErrorf("Failed to report logs on github issue: %v", err)
-					server.SetHealth(false, hash)
+					server.SetHealth(false, healthz)
 				}
 			} else if err := CloseIssue(token, cfg.TargetOrg, cfg.SourceRepo, cfg.GithubIssue); err != nil {
 				githubIssueErrorf("Failed to close issue: %v", err)
-				server.SetHealth(false, hash)
+				server.SetHealth(false, healthz)
 			}
 		} else {
 			// run


### PR DESCRIPTION
@sttts the idea here is to get more useful info from the publisher bot runtime, so we can have some simple dashboard to display the history of runs and the status for different runs (instead of digging in GH issue ;-)

The data I would like to see are:

* Last publisher bot error
* The HEAD SHA256 for every branch (not just "master")
* The HEAD of the branches in rules (so I can fetch the commit message from GH and make sure the commit went to repo it should) (TBD)
* Duration of each run (so we can see if we are getting faster or slower ;-)
* etc...

WDYT?