### PR TITLE
Fix bug: shell syntax error

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -65,7 +65,7 @@ SOURCE_REPO_NAME="${9}"
 shift 9
 
 # base package name (eg. k8s.io)
-BASE_PACKAGE="${1-k8s.io}"
+BASE_PACKAGE="${1:-k8s.io}"
 # If ${REPO} is a library
 IS_LIBRARY="${2}"
 # A ls-files pattern like "*/BUILD *.ext pkg/foo.go Makefile"


### PR DESCRIPTION
Fix bug: shell syntax error, ${1-k8s.io}  -> ${1:-k8s.io}