### PR TITLE
Add component-base repo

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -243,6 +243,20 @@ data:
         godep restore
         go build ./...
         go test $(go list ./... | grep -v /vendor/)
+    - destination: component-base
+      library: true
+      branches:
+      - source:
+          branch: master
+          dir: staging/src/k8s.io/component-base
+        name: master
+        dependencies:
+        - repository: api
+          branch: master
+        - repository: apimachinery
+          branch: master
+        - repository: client-go
+          branch: master
     - destination: apiserver
       library: true
       branches:
@@ -256,6 +270,8 @@ data:
         - repository: api
           branch: master
         - repository: client-go
+          branch: master
+        - repository: component-base
           branch: master
       # - source:
       #     branch: release-1.6
@@ -360,6 +376,8 @@ data:
         - repository: client-go
           branch: master
         - repository: apiserver
+          branch: master
+        - repository: component-base
           branch: master
       # - source:
       #     branch: release-1.6
@@ -482,6 +500,8 @@ data:
         - repository: apiserver
           branch: master
         - repository: code-generator
+          branch: master
+        - repository: component-base
           branch: master
         required-packages:
         - k8s.io/code-generator
@@ -636,6 +656,8 @@ data:
         - repository: client-go
           branch: master
         - repository: code-generator
+          branch: master
+        - repository: component-base
           branch: master
         required-packages:
         - k8s.io/code-generator
@@ -1057,6 +1079,8 @@ data:
           branch: master
         - repository: client-go
           branch: master
+        - repository: component-base
+          branch: master
       - source:
           branch: release-1.12
           dir: staging/src/k8s.io/sample-cli-plugin
@@ -1094,6 +1118,8 @@ data:
         name: master
         dependencies:
         - repository: apimachinery
+          branch: master
+        - repository: component-base
           branch: master
       - source:
           branch: release-1.12
@@ -1155,6 +1181,8 @@ data:
           branch: master
         - repository: apiserver
           branch: master
+        - repository: component-base
+          branch: master
       - source:
           branch: release-1.12
           dir: staging/src/k8s.io/kube-scheduler
@@ -1186,6 +1214,8 @@ data:
         - repository: apimachinery
           branch: master
         - repository: apiserver
+          branch: master
+        - repository: component-base
           branch: master
       - source:
           branch: release-1.12

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -33,27 +33,27 @@ if [ "$#" -ge 2 ]; then
 fi
 GITHUB_HOST=${GITHUB_HOST:-github.com}
 repos=(
-    apimachinery
     api
-    client-go
-    apiserver
-    kube-aggregator
-    sample-apiserver
-    sample-controller
     apiextensions-apiserver
-    metrics
-    code-generator
-    csi-api
-    sample-cli-plugin
+    apimachinery
+    apiserver
+    client-go
     cli-runtime
-    kube-proxy
-    kubelet
-    kube-scheduler
-    kube-controller-manager
-    cluster-bootstrap
     cloud-provider
-    node-api
+    cluster-bootstrap
+    code-generator
     component-base
+    csi-api
+    kube-aggregator
+    kube-controller-manager
+    kubelet
+    kube-proxy
+    kube-scheduler
+    metrics
+    node-api
+    sample-apiserver
+    sample-cli-plugin
+    sample-controller
 )
 
 repo_count=${#repos[@]}

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -53,6 +53,7 @@ repos=(
     cluster-bootstrap
     cloud-provider
     node-api
+    component-base
 )
 
 repo_count=${#repos[@]}


### PR DESCRIPTION
- Repo creation request: https://github.com/kubernetes/org/issues/330
- Repo with initial empty commit: https://github.com/kubernetes/component-base
- PR against test-infra for branch protection: https://github.com/kubernetes/test-infra/pull/10635
- PR for staging against k/k: https://github.com/kubernetes/kubernetes/pull/72569
- Dependencies: As per PR [`Godeps.json`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/Godeps/Godeps.json),
  -  only apimachinery is a dependency.
  - `component-base` is a dependency to `kube-proxy`, `kube-scheduler` and `kube-controller-manager`.
  - it is safe to add future dependencies per https://github.com/kubernetes/publishing-bot/pull/142#discussion_r245485117 as well, so they have been added too.


/cc @luxas @sttts 
/assign @sttts 

/hold 

I'll consider it safe to cancel the hold when:
- [x] The published repo has been created and has an initial empty commit: https://github.com/kubernetes/component-base.
- [x] The PR against staging (https://github.com/kubernetes/kubernetes/pull/72569) has merged.
- [x] Dependencies are verified after the above PR is merged (just to double check). Note: future dependencies have also been added.
- [x] The PR against test-infra for branch protection is merged (https://github.com/kubernetes/test-infra/pull/10635)



