### PR TITLE
Add csi-translation-lib repo

### DIFF
--- a/configs/kubernetes-rules-configmap.yaml
+++ b/configs/kubernetes-rules-configmap.yaml
@@ -1299,3 +1299,15 @@ data:
           branch: master
         - repository: client-go
           branch: master
+    - destination: csi-translation-lib
+      library: true
+      branches:
+      - source:
+          branch: master
+          dir: staging/src/k8s.io/csi-translation-lib
+        name: master
+        dependencies:
+        - repository: api
+          branch: master
+        - repository: apimachinery
+          branch: master

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -44,6 +44,7 @@ repos=(
     code-generator
     component-base
     csi-api
+    csi-translation-lib
     kube-aggregator
     kube-controller-manager
     kubelet


### PR DESCRIPTION
- Repo creation request: https://github.com/kubernetes/org/issues/321
- Repo with initial empty commit: https://github.com/kubernetes/csi-translation-lib
- PR against test-infra for branch protection: https://github.com/kubernetes/test-infra/pull/10676
- PR for staging against k/k: https://github.com/kubernetes/kubernetes/pull/72770
- Dependencies: As per the [`Godeps.json`](https://github.com/kubernetes/kubernetes/blob/ab2e26386f9a309feda55e735b28db8919921c3f/staging/src/k8s.io/csi-translation-lib/Godeps/Godeps.json) in the PR, the csi-translation-lib depends on `api` and `apimachinery` and no other staging repos depend on it.
 
/cc @ddebroy @sttts 
/assign @sttts 

/hold 

until:
- [x] The PR against staging (https://github.com/kubernetes/kubernetes/pull/72770) has merged.
- [ ] Dependencies are verified after the above PR is merged.