### PR TITLE
Increase memory limits to survive smoke-test

### DIFF
--- a/configs/kubernetes
+++ b/configs/kubernetes
@@ -2,5 +2,5 @@ DOCKER_REPO = sttts/k8s-publishing-bot
 NAMESPACE = k8s-publishing-bot
 SCHEDULE = * */4 * * *
 INTERVAL = 14400
-MEMORY_REQUESTS = 1.5Gi
-MEMORY_LIMITS = 2Gi
+MEMORY_REQUESTS = 2Gi
+MEMORY_LIMITS = 3Gi


### PR DESCRIPTION
The linker gets killed due to memory with 1.5Gi.