### PR TITLE
Bump default go version to 1.11.5

### DIFF
--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -18,7 +18,7 @@ import (
 const (
 	depCommit        = "7c44971bbb9f0ed87db40b601f2d9fe4dffb750d"
 	godepCommit      = "tags/v80"
-	DefaultGoVersion = "1.11.4"
+	DefaultGoVersion = "1.11.5"
 )
 
 var (


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/73326

/assign @sttts 