### PR TITLE
go-mod support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
  && apt-get install -y -qq git=1:2.11.0-3+deb9u4 \
  && apt-get install -y -qq mercurial \
- && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc \
+ && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH="/go-workspace"
@@ -35,6 +35,8 @@ ADD _output/publishing-bot /publishing-bot
 ADD _output/collapsed-kube-commit-mapper /collapsed-kube-commit-mapper
 ADD _output/sync-tags /sync-tags
 ADD _output/init-repo /init-repo
+
+ADD _output/godeps-gen /godeps-gen
 ADD artifacts/scripts/ /publish_scripts
 
 CMD ["/publishing-bot", "--dry-run", "--token-file=/token"]

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ build:
 	$(call build_cmd,publishing-bot)
 	$(call build_cmd,sync-tags)
 	$(call build_cmd,init-repo)
+	$(call build_cmd,godeps-gen)
 .PHONY: build
 
 build-image: build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The publishing bot publishes the code in `k8s.io/kubernetes/staging` to their ow
 
 It pulls the latest k8s.io/kubernetes changes and runs `git filter-branch` to distill the commits that affect a staging repo. Then it cherry-picks merged PRs with their feature branch commits to the target repo. It records the SHA1 of the last cherrypicked commits in `Kubernetes-sha: <sha>` lines in the commit messages.
 
-The robot is also responsible to update the `Godeps/Godeps.json` and the `vendor/` directory for the target repos.
+The robot is also responsible to update the `go-mod` and the `vendor/` directory for the target repos, and to create a fake (sparse and repo level based) `Godeps/Godeps.json`.
 
 ## Playbook
 

--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -142,18 +142,18 @@ PUSH_SCRIPT=../push-tags-${REPO}-${DST_BRANCH}.sh
 echo "#!/bin/bash" > ${PUSH_SCRIPT}
 chmod +x ${PUSH_SCRIPT}
 
-if [ -z "${SKIP_TAGS}" ]; then
-    /sync-tags --prefix "$(echo ${SOURCE_REPO_NAME})-" \
-               --commit-message-tag $(echo ${SOURCE_REPO_NAME} | sed 's/^./\L\u&/')-commit \
-               --source-remote upstream --source-branch "${SRC_BRANCH}" \
-               --push-script ${PUSH_SCRIPT} \
-               --dependencies "${DEPS}" \
-               --mapping-output-file "../tag-${REPO}-{{.Tag}}-mapping" \
-               -alsologtostderr \
-               "${EXTRA_ARGS[@]-}"
-    if [ "${LAST_HEAD}" != "$(git rev-parse ${LAST_BRANCH})" ]; then
-        echo "Unexpected: branch ${LAST_BRANCH} has diverted to $(git rev-parse HEAD) from ${LAST_HEAD} before tagging."
-        exit 1
-    fi
-fi
+# if [ -z "${SKIP_TAGS}" ]; then
+#    /sync-tags --prefix "$(echo ${SOURCE_REPO_NAME})-" \
+#               --commit-message-tag $(echo ${SOURCE_REPO_NAME} | sed 's/^./\L\u&/')-commit \
+#               --source-remote upstream --source-branch "${SRC_BRANCH}" \
+#               --push-script ${PUSH_SCRIPT} \
+#               --dependencies "${DEPS}" \
+#               --mapping-output-file "../tag-${REPO}-{{.Tag}}-mapping" \
+#               -alsologtostderr \
+#               "${EXTRA_ARGS[@]-}"
+#    if [ "${LAST_HEAD}" != "$(git rev-parse ${LAST_BRANCH})" ]; then
+#        echo "Unexpected: branch ${LAST_BRANCH} has diverted to $(git rev-parse HEAD) from ${LAST_HEAD} before tagging."
+#        exit 1
+#    fi
+# fi
 git checkout ${LAST_BRANCH}

--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -97,6 +97,7 @@ echo "Fetching from origin."
 git fetch origin --no-tags --prune
 echo "Cleaning up checkout."
 git rebase --abort >/dev/null || true
+rm -f .git/index.lock || true
 git reset -q --hard
 git clean -q -f -f -d
 git checkout -q $(git rev-parse HEAD) || true

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -554,7 +554,7 @@ EOF
 # amend-gomod-at checks out the go.mod at the given commit and amend it to the previous commit.
 function amend-gomod-at() {
     if [ -f go.mod ]; then
-        git checkout ${f_mainline_commit} go.mod # reset to mainline state which is guaranteed to be correct
+        git checkout ${f_mainline_commit} go.mod go.sum # reset to mainline state which is guaranteed to be correct
         git commit --amend --no-edit -q
     fi
 }
@@ -630,9 +630,9 @@ function show-working-dir-status() {
 
 function gomod-changes() {
     if [ -n "${2:-}" ]; then
-        ! git diff --exit-code --quiet ${1} ${2} -- go.mod
+        ! git diff --exit-code --quiet ${1} ${2} -- go.mod go.sum
     else
-        ! git diff --exit-code --quiet $(state-before-commit ${1}) ${1} -- go.mod
+        ! git diff --exit-code --quiet $(state-before-commit ${1}) ${1} -- go.mod go.sum
     fi
 }
 
@@ -735,7 +735,7 @@ function fix-gomod() {
             echo "Resolving dependencies for Godeps.json generation"
             GOPROXY="file://${GOPATH}/pkg/mod/cache/download" GO111MODULE=on go list -m -json all > /tmp/go-list
             /godeps-gen /tmp/go-list Godeps/Godeps.json
-            git add Godeps go.mod # go.mod is surprisingly written: EOF newline
+            git add Godeps go.mod go.sum # go.mod is surprisingly written: EOF newline
             if ! git-index-clean; then
                 git commit -q -m "sync: update Godeps/Godeps.json"
             fi
@@ -786,11 +786,11 @@ function reset-gomod() {
 
     # checkout or delete go.mod
     if [ -n "$(git ls-tree ${f_clean_commit}^{tree} go.mod)" ]; then
-        git checkout ${f_clean_commit} go.mod
-        git add go.mod
+        git checkout ${f_clean_commit} go.mod go.sum
+        git add go.mod go.sum
     elif [ -f go.mod ]; then
-        rm -f go.mod
-        git rm -f go.mod
+        rm -f go.mod go.sum
+        git rm -f go.mod go.sum
     fi
 
     # commit go.mod unconditionally

--- a/cmd/godeps-gen/main.go
+++ b/cmd/godeps-gen/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var debug = false
+
+func main() {
+	if len(os.Args) < 2 || len(os.Args) > 4 {
+		fmt.Fprintln(os.Stderr, "This tool generates a Godeps.json file based on an input file containing dependency information.")
+		fmt.Fprintln(os.Stderr, "usage: gen-godeps <input-file> [<output-file>]")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "  <input-file> should contain the result of running 'GO111MODULE=on go list -m -json all'")
+		fmt.Fprintln(os.Stderr, "  <output-file> is a Godeps.json file. if <output-file> is omitted, content is written to stdout")
+		os.Exit(1)
+	}
+
+	inputFile := os.Args[1]
+
+	f, err := os.Open(inputFile)
+	checkErr(err)
+	defer f.Close()
+
+	decoder := json.NewDecoder(f)
+	deps := []GoListDep{}
+	for {
+		dep := &GoListDep{}
+		err := decoder.Decode(dep)
+		if err == nil {
+			deps = append(deps, *dep)
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+		checkErr(err)
+	}
+
+	sort.SliceStable(deps, func(i, j int) bool { return deps[i].Path < deps[j].Path })
+
+	godeps := Godeps{
+		GoVersion:    "unknown",
+		GodepVersion: "gen-godeps",
+		Packages:     []string{"./..."},
+	}
+	for _, dep := range deps {
+		if dep.Main {
+			godeps.ImportPath = dep.Path
+			continue
+		}
+
+		version := dep.Version
+		if len(dep.Replace.Path) > 0 {
+			switch {
+			case dep.Replace.Path == dep.Path:
+				// pinned replacement, use the replaced version
+				if debug {
+					fmt.Fprintf(os.Stderr, "use replaced version for %q\n", dep.Path)
+				}
+				version = dep.Replace.Version
+			case (strings.HasPrefix(dep.Replace.Path, "./") || strings.HasPrefix(dep.Replace.Path, "../")) && len(dep.Replace.Version) == 0:
+				// relative path, use the required version
+				if debug {
+					fmt.Fprintf(os.Stderr, "use required version for relative %q\n", dep.Path)
+				}
+			default:
+				// replacement path != source path, we can't generate a usable godeps.json
+				checkErr(fmt.Errorf("dependency %q was replaced with %q, cannot generate godeps", dep.Path, dep.Replace.Path))
+			}
+		} else {
+			if debug {
+				fmt.Fprintf(os.Stderr, "use required version for %q\n", dep.Path)
+			}
+		}
+		rev, err := versionToRev(dep.Path, version)
+		checkErr(err)
+		godeps.Deps = append(godeps.Deps, GodepDep{ImportPath: dep.Path, Rev: rev})
+	}
+
+	godepJSON, err := json.MarshalIndent(godeps, "", "\t")
+	checkErr(err)
+
+	if len(os.Args) > 2 {
+		outputFile := os.Args[2]
+		checkErr(os.MkdirAll(filepath.Dir(outputFile), os.FileMode(755)))
+		checkErr(ioutil.WriteFile(outputFile, godepJSON, os.FileMode(0644)))
+	} else {
+		fmt.Println(string(godepJSON))
+	}
+}
+
+var (
+	// https://tip.golang.org/cmd/go/#hdr-Pseudo_versions
+	pseudoVersion = regexp.MustCompile(`(-0\.|\.0\.|-)\d{14}-([0-9a-f]{12})(\+incompatible)?$`)
+)
+
+func versionToRev(path, version string) (string, error) {
+	switch {
+	// pseudo version (v0.0.0-20180207000608-0eeff89b0690)
+	case pseudoVersion.FindStringSubmatch(version) != nil:
+		sha := pseudoVersion.FindStringSubmatch(version)[2]
+		if sha == "000000000000" {
+			return "", fmt.Errorf("unknown version sha: %q: %q", path, version)
+		}
+		return sha, nil
+
+	default:
+		if version == "v0.0.0" {
+			return "", fmt.Errorf("unknown version tag: %q: %q", path, version)
+		}
+		// https://tip.golang.org/cmd/go/#hdr-Module_compatibility_and_semantic_versioning
+		return strings.TrimSuffix(version, "+incompatible"), nil
+	}
+}
+
+func checkErr(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+type GoListDep struct {
+	Path    string
+	Version string
+	Main    bool
+	Replace GoListReplace
+}
+type GoListReplace struct {
+	Path    string
+	Version string
+}
+
+type Godeps struct {
+	ImportPath   string
+	GoVersion    string
+	GodepVersion string
+	Packages     []string
+	Deps         []GodepDep
+}
+
+type GodepDep struct {
+	ImportPath string
+	Rev        string
+}

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -215,12 +215,16 @@ func run(c *exec.Cmd) {
 }
 
 func cloneSourceRepo(cfg config.Config, runGodepRestore bool) {
+	repoLocation := fmt.Sprintf("https://%s/%s/%s", cfg.GithubHost, cfg.SourceOrg, cfg.SourceRepo)
+
 	if _, err := os.Stat(filepath.Join(BaseRepoPath, cfg.SourceRepo)); err == nil {
-		glog.Infof("Source repository %q already cloned, skipping", cfg.SourceRepo)
+		glog.Infof("Source repository %q already cloned, only setting remote", cfg.SourceRepo)
+		remoteCmd := exec.Command("git", "remote", "set-url", "origin", repoLocation)
+		remoteCmd.Dir = filepath.Join(BaseRepoPath, cfg.SourceRepo)
+		run(remoteCmd)
 		return
 	}
 
-	repoLocation := fmt.Sprintf("https://%s/%s/%s", cfg.GithubHost, cfg.SourceOrg, cfg.SourceRepo)
 	glog.Infof("Cloning source repository %s ...", repoLocation)
 	cloneCmd := exec.Command("git", "clone", repoLocation)
 	run(cloneCmd)

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -67,6 +67,7 @@ type RepositoryRule struct {
 type RepositoryRules struct {
 	SkippedSourceBranches []string         `yaml:"skip-source-branches"`
 	SkipGodeps            bool             `yaml:"skip-godeps"`
+	SkipGomod             bool             `yaml:"skip-gomod"`
 	SkipTags              bool             `yaml:"skip-tags"`
 	Rules                 []RepositoryRule `yaml:"rules"`
 


### PR DESCRIPTION
This removes godeps support and adds generation of go.mod+sum. No vendor/ is generated anymore.

In parallel, there is a godeps branch forked off before this PR. We will keep running a second instance for all pre-1.15 versions.