### PR TITLE
Add new staging repo: cri-api

### DIFF
--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -43,6 +43,7 @@ repos=(
     cluster-bootstrap
     code-generator
     component-base
+    cri-api
     csi-api
     csi-translation-lib
     kube-aggregator


### PR DESCRIPTION
Ref:

- Repo creation request: https://github.com/kubernetes/org/issues/642
- Repo with initial empty commit: https://github.com/kubernetes/cri-api
- PR against test-infra for branch protection: https://github.com/kubernetes/test-infra/pull/11941
- PR for to add repo to staging against k/k: https://github.com/kubernetes/kubernetes/pull/75531
- PR for updating publishing-bot rules against k/k: https://github.com/kubernetes/kubernetes/pull/75531

/hold
This needs to be added to staging and the rules need to be updated

/assign @dims @sttts 