### PR TITLE
Add new staging repo: legacy-cloud-providers

### DIFF
--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -51,6 +51,7 @@ repos=(
     kubelet
     kube-proxy
     kube-scheduler
+    legacy-cloud-providers
     metrics
     node-api
     sample-apiserver


### PR DESCRIPTION
Ref:

- Repo creation request: https://github.com/kubernetes/org/issues/719
- Repo with initial empty commit: https://github.com/kubernetes/legacy-cloud-providers
- PR against test-infra for branch protection: https://github.com/kubernetes/test-infra/pull/12220
- PR for to add repo to staging against k/k: https://github.com/kubernetes/kubernetes/pull/75910
- PR for updating publishing-bot rules against k/k: https://github.com/kubernetes/kubernetes/pull/75910/commits/8e508598982bbd9b392eaf7b0aaaed6f833a9e94#diff-91f67bda331c4de19a3b70c86f69a080
- @kubernetes/stage-bots team has admin access to the repo :heavy_check_mark: 

/hold
Needs to be added to staging, rules need to be updated and branch protection PR needs to be merged.

/cc @dims @sttts @andrewsykim 
/assign @sttts 