### PR TITLE
Don't apply empty patch when merge commit is direct descendant of branch point commit

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -439,12 +439,14 @@ sync_repo() {
                     dst_needs_gomod_update=true
                 fi
 
-                if ! git diff ${f_latest_branch_point_commit} ${f_latest_merge_commit} | git apply --index; then
-                    echo
-                    show-working-dir-status
-                    return 1
+                if ! git diff --quiet --exit-code ${f_latest_branch_point_commit} ${f_latest_merge_commit}; then
+                    if ! git diff ${f_latest_branch_point_commit} ${f_latest_merge_commit}  | git apply --index; then
+                        echo
+                        show-working-dir-status
+                        return 1
+                    fi
                 fi
-                git commit -q -m "sync: squashed up to merge $(kube-commit ${commit_msg_tag} ${f_latest_merge_commit}) in ${k_mainline_commit}" --date "$(commit-date ${f_latest_merge_commit})" --author "$(commit-author ${f_latest_merge_commit})"
+                git commit --allow-empty -q -m "sync: squashed up to merge $(kube-commit ${commit_msg_tag} ${f_latest_merge_commit}) in ${k_mainline_commit}" --date "$(commit-date ${f_latest_merge_commit})" --author "$(commit-author ${f_latest_merge_commit})"
                 ensure-clean-working-dir
 
                 # potentially squash go.mod reset commit


### PR DESCRIPTION
When `f_latest_merge_commit` is a direct descendant of `f_latest_branch_point_commit` - this can occur while doing a `git merge --no-ff` when it should have been a fast forward merge - there will be no diff between them. Applying an empty patch will give an error.

So, apply the patch only if it exists and allow an empty commit so that the go.mod changes can be squashed
with this commit later, if needed.

---

In the current case:
- `f_latest_merge_commit` is `0b6b7933b323bfa1127d27eb580ca17a7bd66ae1` - "Merge branch 'master' of https://github.com/kubernetes/kubernetes into fix-golint-utils-bandwith"
- `f_latest_branch_point_commit` is `5ee4f206df86965a75ed5aaf880f98161c70a9c1` - "Merge pull request #75849 from jpbetz/pagination-podgc"

<details open>
<summary>Relevant part of the logs</summary>

```
	++ git merge-base --octopus '77b631660d4a33f753fab759f29c97bafe4c830c^1' '77b631660d4a33f753fab759f29c97bafe4c830c^2'
	+ local f_latest_branch_point_commit=5ee4f206df86965a75ed5aaf880f98161c70a9c1
	+ '[' -z 5ee4f206df86965a75ed5aaf880f98161c70a9c1 ']'
	+ local f_first_pick_base=5ee4f206df86965a75ed5aaf880f98161c70a9c1
	++ git log --merges --format=%H --ancestry-path -1 '5ee4f206df86965a75ed5aaf880f98161c70a9c1..77b631660d4a33f753fab759f29c97bafe4c830c^2'
	+ local f_latest_merge_commit=0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	+ '[' -n 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1 ']'
	++ kube-commit Kubernetes-commit 5ee4f206df86965a75ed5aaf880f98161c70a9c1
	++ local commit_msg_tag=Kubernetes-commit
	++ commit-message 5ee4f206df86965a75ed5aaf880f98161c70a9c1
	++ git show --format=%B -q 5ee4f206df86965a75ed5aaf880f98161c70a9c1
	++ grep '^Kubernetes-commit: '
	++ sed 's/^Kubernetes-commit: //g'
	++ kube-commit Kubernetes-commit 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	++ local commit_msg_tag=Kubernetes-commit
	++ commit-message 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	++ git show --format=%B -q 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	++ grep '^Kubernetes-commit: '
	++ sed 's/^Kubernetes-commit: //g'
	++ commit-subject 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	++ git show --format=%s -q 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	Cherry-picking squashed k8s.io/kubernetes branch-commits d5dbc0019123f42c678a1f012a068941d56087c8..69bd30507559be3dea905686b46bc3295c951f45 because the last one is a merge: Merge branch 'master' of https://github.com/kubernetes/kubernetes into fix-golint-utils-bandwith
	+ echo 'Cherry-picking squashed k8s.io/kubernetes branch-commits d5dbc0019123f42c678a1f012a068941d56087c8..69bd30507559be3dea905686b46bc3295c951f45 because the last one is a merge: Merge branch '\''master'\'' of https://github.com/kubernetes/kubernetes into fix-golint-utils-bandwith'
	+ local squash_commits=1
	+ gomod-changes 5ee4f206df86965a75ed5aaf880f98161c70a9c1 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	+ '[' -n 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1 ']'
	+ git diff --exit-code --quiet 5ee4f206df86965a75ed5aaf880f98161c70a9c1 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1 -- go.mod go.sum
	+ godeps-changes 5ee4f206df86965a75ed5aaf880f98161c70a9c1 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	+ '[' -n 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1 ']'
	+ git diff --exit-code --quiet 5ee4f206df86965a75ed5aaf880f98161c70a9c1 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1 -- Godeps/Godeps.json
	+ git diff 5ee4f206df86965a75ed5aaf880f98161c70a9c1 0b6b7933b323bfa1127d27eb580ca17a7bd66ae1
	+ git apply --index
	error: unrecognized input
```
</details>

![Screenshot from 2019-05-27 19-49-03](https://user-images.githubusercontent.com/16105680/58425972-ea9ce780-80b8-11e9-9f8d-04b70546661a.png)

/cc @sttts @dims 
/assign @sttts 