### PR TITLE
Add new staging repo: kubectl

### DIFF
--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -48,6 +48,7 @@ repos=(
     csi-translation-lib
     kube-aggregator
     kube-controller-manager
+    kubectl
     kubelet
     kube-proxy
     kube-scheduler


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/pull/77762. This will actually switch on the publishing-bot for the kubectl repo.

/hold
until https://github.com/kubernetes/kubernetes/pull/77762 and https://github.com/kubernetes/test-infra/pull/12794 have merged

/cc @seans3 @dims @sttts 
/assign @sttts 