### PR TITLE
Enable sync-tags only for main publishing-bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ WORKDIR "/"
 
 ADD _output/publishing-bot /publishing-bot
 ADD _output/collapsed-kube-commit-mapper /collapsed-kube-commit-mapper
-ADD _output/sync-tags /sync-tags
 ADD _output/init-repo /init-repo
 ADD artifacts/scripts/ /publish_scripts
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ SHELL := /bin/bash
 build:
 	$(call build_cmd,collapsed-kube-commit-mapper)
 	$(call build_cmd,publishing-bot)
-	$(call build_cmd,sync-tags)
 	$(call build_cmd,init-repo)
 .PHONY: build
 

--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -141,18 +141,4 @@ PUSH_SCRIPT=../push-tags-${REPO}-${DST_BRANCH}.sh
 echo "#!/bin/bash" > ${PUSH_SCRIPT}
 chmod +x ${PUSH_SCRIPT}
 
-if [ -z "${SKIP_TAGS}" ]; then
-    /sync-tags --prefix "$(echo ${SOURCE_REPO_NAME})-" \
-               --commit-message-tag $(echo ${SOURCE_REPO_NAME} | sed 's/^./\L\u&/')-commit \
-               --source-remote upstream --source-branch "${SRC_BRANCH}" \
-               --push-script ${PUSH_SCRIPT} \
-               --dependencies "${DEPS}" \
-               --mapping-output-file "../tag-${REPO}-{{.Tag}}-mapping" \
-               -alsologtostderr \
-               "${EXTRA_ARGS[@]-}"
-    if [ "${LAST_HEAD}" != "$(git rev-parse ${LAST_BRANCH})" ]; then
-        echo "Unexpected: branch ${LAST_BRANCH} has diverted to $(git rev-parse HEAD) from ${LAST_HEAD} before tagging."
-        exit 1
-    fi
-fi
 git checkout ${LAST_BRANCH}


### PR DESCRIPTION
sync-tags is [disabled](https://github.com/kubernetes/publishing-bot/commit/31e2757859d1f3d65a8593e502c5f0880ad105bc) for the main publishing-bot because gomodules
support hasn't been implemented yet. But it remained enabled for the
godeps branch, which meant that tagging still took place but didn't
include go.mod files at all.

This commit removes sync-tags support from the godeps branch, so that it
can be enabled for the main publishing-bot from the master branch later
(after gomodules support has been added).

Relevant slack thread - https://kubernetes.slack.com/archives/C2C40FMNF/p1560158651078000

/assign @sttts @dims 