### PR TITLE
Fix go mod publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ADD _output/sync-tags /sync-tags
 ADD _output/init-repo /init-repo
 
 ADD _output/godeps-gen /godeps-gen
+ADD _output/gomod-zip /gomod-zip
 ADD artifacts/scripts/ /publish_scripts
 
 CMD ["/publishing-bot", "--dry-run", "--token-file=/token"]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ build:
 	$(call build_cmd,sync-tags)
 	$(call build_cmd,init-repo)
 	$(call build_cmd,godeps-gen)
+	$(call build_cmd,gomod-zip)
 .PHONY: build
 
 build-image: build

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -932,9 +932,7 @@ checkout-deps-to-kube-commit() {
             	cp go.mod "${cache_dir}/${pseudo_version}.mod"
                 echo "{\"Version\":\"${pseudo_version}\",\"Name\":\"$(git rev-parse HEAD)\",\"Short\":\"$(git show -q --abbrev=12 --pretty='format:%h' HEAD)\",\"Time\":\"$(TZ=GMT git show -q --pretty='format:%cd' --date='format:%Y-%m-%dT%H:%M:%SZ')\"}" > "${cache_dir}/${pseudo_version}.info"
                 pushd "${GOPATH}/src" >/dev/null
-                mv "${base_package}/${dep}" "${base_package}/${dep}@${pseudo_version}"
-                zip -y -x "${base_package}/${dep}@${pseudo_version}/.git/*" -q -r "${cache_dir}/${pseudo_version}.zip" "${base_package}/${dep}@${pseudo_version}"
-                mv "${base_package}/${dep}@${pseudo_version}" "${base_package}/${dep}"
+                /gomod-zip --package-name="${base_package}/${dep}" --pseudo-version="${pseudo_version}"
                 popd >/dev/null
                 echo "${pseudo_version}" >> "${cache_dir}/list"
             fi

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -880,7 +880,7 @@ update-deps-in-gomod() {
 }
 
 gomod-pseudo-version() {
-    TZ=GMT git show -q --pretty='format:v0.0.0-%cd-%h' --date='format:%Y%m%d%H%M%S' --abbrev=12
+    TZ=GMT git show -q --pretty='format:v0.0.0-%cd-%h' --date='format-local:%Y%m%d%H%M%S' --abbrev=12
 }
 
 # checkout the dependencies to the versions corresponding to the kube commit of HEAD
@@ -930,7 +930,7 @@ checkout-deps-to-kube-commit() {
             	echo "Packaging up pseudo version ${pseudo_version} into go mod cache..."
             	mkdir -p "${cache_dir}"
             	cp go.mod "${cache_dir}/${pseudo_version}.mod"
-                echo "{\"Version\":\"${pseudo_version}\",\"Name\":\"$(git rev-parse HEAD)\",\"Short\":\"$(git show -q --abbrev=12 --pretty='format:%h' HEAD)\",\"Time\":\"$(TZ=GMT git show -q --pretty='format:%cd' --date='format:%Y-%m-%dT%H:%M:%SZ')\"}" > "${cache_dir}/${pseudo_version}.info"
+                echo "{\"Version\":\"${pseudo_version}\",\"Name\":\"$(git rev-parse HEAD)\",\"Short\":\"$(git show -q --abbrev=12 --pretty='format:%h' HEAD)\",\"Time\":\"$(TZ=GMT git show -q --pretty='format:%cd' --date='format-local:%Y-%m-%dT%H:%M:%SZ')\"}" > "${cache_dir}/${pseudo_version}.info"
                 pushd "${GOPATH}/src" >/dev/null
                 /gomod-zip --package-name="${base_package}/${dep}" --pseudo-version="${pseudo_version}"
                 popd >/dev/null

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -920,7 +920,7 @@ checkout-deps-to-kube-commit() {
             git checkout -q "${dep_commit}"
 
             echo "Downloading go mod dependencies..."
-            go mod download
+            GO111MODULE=on go mod download
 
             local pseudo_version=$(gomod-pseudo-version)
             local cache_dir="${GOPATH}/pkg/mod/cache/download/${base_package}/${dep}/@v"

--- a/cmd/gomod-zip/zip.go
+++ b/cmd/gomod-zip/zip.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// MaxZipFile is the maximum size of downloaded zip file
+	MaxZipFile = 500 << 20
+)
+
+func Usage() {
+	fmt.Fprintf(os.Stderr, `Creates a zip file at
+$GOPATH/pkg/mod/cache/download/<package-name>/@v/<pseudo-version>.zip.
+The zip file has the same hash as if it were created by go mod download.
+This tool can be used to package modules which haven't been uploaded anywhere
+yet and are only available locally.
+
+This tool assumes that the package is already checked out at the commit
+pointed by the pseudo-version.
+
+package-name should be equal to the import path of the package.
+
+Usage: %s --package-name <package-name> --pseudo-version <pseudo-version>
+`, os.Args[0])
+	flag.PrintDefaults()
+}
+
+func main() {
+	packageName := flag.String("package-name", "", "package to zip")
+	pseudoVersion := flag.String("pseudo-version", "", "pseudoVersion to zip at")
+	flag.Parse()
+
+	if *packageName == "" {
+		glog.Fatalf("package-name cannot be empty")
+	}
+
+	if *pseudoVersion == "" {
+		glog.Fatalf("pseudo-version cannot be empty")
+	}
+
+	// create a zip file using git archive, and remove it after using it
+	depPseudoVersion := fmt.Sprintf("%s@%s", *packageName, *pseudoVersion)
+	zipFileName := fmt.Sprintf("%s/src/%s/%s.zip", os.Getenv("GOPATH"), *packageName, *pseudoVersion)
+	prefix := fmt.Sprintf("%s/", depPseudoVersion)
+	gitArchive := exec.Command("git", "archive", "--format=zip", "--prefix", prefix, "-o", zipFileName, "HEAD")
+	gitArchive.Dir = fmt.Sprintf("%s/src/%s", os.Getenv("GOPATH"), *packageName)
+	gitArchive.Stdout = os.Stdout
+	gitArchive.Stderr = os.Stderr
+	if err := gitArchive.Run(); err != nil {
+		glog.Fatalf("unable to run git archive for %s at %s: %v", *packageName, *pseudoVersion, err)
+	}
+	defer os.Remove(zipFileName)
+
+	archive, err := ioutil.ReadFile(zipFileName)
+	if err != nil {
+		glog.Fatalf("error reading zip file %s: %v", zipFileName, err)
+	}
+
+	dl := ioutil.NopCloser(bytes.NewReader(archive))
+	defer dl.Close()
+
+	// This is taken from https://github.com/golang/go/blob/b373d31c25e58d0b69cff3521b915f0c06fa6ac8/src/cmd/go/internal/modfetch/coderepo.go#L459.
+	// Spool to local file.
+	f, err := ioutil.TempFile("", "gomodzip-")
+	if err != nil {
+		dl.Close()
+		glog.Fatalf("error creating temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	maxSize := int64(MaxZipFile)
+	lr := &io.LimitedReader{R: dl, N: maxSize + 1}
+	if _, err := io.Copy(f, lr); err != nil {
+		dl.Close()
+		glog.Fatalf("error reading from %s: %v", f.Name(), err)
+	}
+
+	if lr.N <= 0 {
+		glog.Fatalf("downloaded zip file too large")
+	}
+	size := (maxSize + 1) - lr.N
+	if _, err := f.Seek(0, 0); err != nil {
+		glog.Fatal(err)
+	}
+
+	// The zip file created by go mod download has extra normalization over
+	// the zip file created by git archive. The normalization process is done below.
+	//
+	// While the normalization can also be achieved via a simple zip command, the zip file
+	// created by go mod download has the `00-00-1980 00:00` timestamp in the file header
+	// for all files in the zip archive. This is not a valid UNIX timestamp and cannot be
+	// set easily. This is, however, valid in MSDOS. The `archive/zip` package uses the
+	// MSDOS version so we create the zip file using this package.
+	zr, err := zip.NewReader(f, size)
+	if err != nil {
+		glog.Fatalf("error reading %s: %v", f.Name(), err)
+	}
+
+	packagedZipPath := fmt.Sprintf("%s/pkg/mod/cache/download/%s/@v/%s.zip", os.Getenv("GOPATH"), *packageName, *pseudoVersion)
+	dst, err := os.OpenFile(packagedZipPath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		glog.Fatalf("failed to create zip file at %s: %v", packagedZipPath, err)
+	}
+	defer dst.Close()
+	zw := zip.NewWriter(dst)
+
+	for _, zf := range zr.File {
+		// Skip symlinks (golang.org/issue/27093)
+		if !zf.FileInfo().Mode().IsRegular() {
+			continue
+		}
+		// drop directory dummy entries
+		if strings.HasSuffix(zf.Name, "/") {
+			continue
+		}
+		// all file paths should have module@version/ prefix
+		if !strings.HasPrefix(zf.Name, prefix) {
+			continue
+		}
+		// inserted by hg archive.
+		// not correct to drop from other version control systems, but too bad.
+		name := strings.TrimPrefix(zf.Name, prefix)
+		if name == ".hg_archival.txt" {
+			continue
+		}
+		// don't consider vendored packages
+		if isVendoredPackage(name) {
+			continue
+		}
+		// make sure we have lower-case go.mod
+		base := path.Base(name)
+		if strings.ToLower(base) == "go.mod" && base != "go.mod" {
+			glog.Fatalf("zip file contains %s, want all lower-case go.mod", zf.Name)
+		}
+
+		size := int64(zf.UncompressedSize64)
+		if size < 0 || maxSize < size {
+			glog.Fatalf("module source tree too big")
+		}
+		maxSize -= size
+
+		rc, err := zf.Open()
+		if err != nil {
+			glog.Fatalf("unable to open file %s: %v", zf.Name, err)
+		}
+		w, err := zw.Create(zf.Name)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		lr := &io.LimitedReader{R: rc, N: size + 1}
+		if _, err := io.Copy(w, lr); err != nil {
+			glog.Fatal(err)
+		}
+		if lr.N <= 0 {
+			glog.Fatalf("individual file too large")
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		glog.Fatal(err)
+	}
+}
+
+func isVendoredPackage(name string) bool {
+	var i int
+	if strings.HasPrefix(name, "vendor/") {
+		i += len("vendor/")
+	} else if j := strings.Index(name, "/vendor/"); j >= 0 {
+		// This offset looks incorrect; this should probably be
+		//
+		// 	i = j + len("/vendor/")
+		//
+		// (See https://golang.org/issue/31562.)
+		//
+		// Unfortunately, we can't fix it without invalidating checksums.
+		// Fortunately, the error appears to be strictly conservative: we'll retain
+		// vendored packages that we should have pruned, but we won't prune
+		// non-vendored packages that we should have retained.
+		//
+		// Since this defect doesn't seem to break anything, it's not worth fixing
+		// for now.
+		i += len("/vendor/")
+	} else {
+		return false
+	}
+	return strings.Contains(name[i:], "/")
+}

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -55,14 +55,18 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		rev := commit.String()
 		pseudoVersion := fmt.Sprintf("v0.0.0-%s-%s", commitTime.UTC().Format("20060102150405"), rev[:12])
 
+		// in case the pseudoVersion has not changed, running go mod download will help
+		// in avoiding packaging it up if the pseudoVersion has been published already
 		downloadCommand := exec.Command("go", "mod", "download")
 		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
 		downloadCommand.Stdout = os.Stdout
 		downloadCommand.Stderr = os.Stderr
 		if err := downloadCommand.Run(); err != nil {
-			return changed, fmt.Errorf("Error running go mod download for %s: %v", depPkg, err)
+			return changed, fmt.Errorf("error running go mod download for %s: %v", depPkg, err)
 		}
 
+		// check if we have the pseudoVersion published already. if we don't, package it up
+		// and save to local mod download cache.
 		if err := packageDepToGoModCache(depPath, depPkg, rev, pseudoVersion, commitTime); err != nil {
 			return changed, fmt.Errorf("failed to package %s dependency: %v", depPkg, err)
 		}
@@ -72,7 +76,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		requireCommand.Stdout = os.Stdout
 		requireCommand.Stderr = os.Stderr
 		if err := requireCommand.Run(); err != nil {
-			return changed, fmt.Errorf("Unable to pin %s in the require section of go.mod to %s: %v", depPkg, pseudoVersion, err)
+			return changed, fmt.Errorf("unable to pin %s in the require section of go.mod to %s: %v", depPkg, pseudoVersion, err)
 		}
 
 		replaceCommand := exec.Command("go", "mod", "edit", "-fmt", "-replace", fmt.Sprintf("%s=%s@%s", depPkg, depPkg, pseudoVersion))
@@ -80,7 +84,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		replaceCommand.Stdout = os.Stdout
 		replaceCommand.Stderr = os.Stderr
 		if err := replaceCommand.Run(); err != nil {
-			return changed, fmt.Errorf("Unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersion, err)
+			return changed, fmt.Errorf("unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersion, err)
 		}
 
 		downloadCommand2 := exec.Command("go", "mod", "download")
@@ -88,7 +92,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		downloadCommand2.Stdout = os.Stdout
 		downloadCommand2.Stderr = os.Stderr
 		if err := downloadCommand2.Run(); err != nil {
-			return changed, fmt.Errorf("Error running go mod download for pseudo-version %s for %s: %v", pseudoVersion, depPkg, err)
+			return changed, fmt.Errorf("error running go mod download for pseudo-version %s for %s: %v", pseudoVersion, depPkg, err)
 		}
 
 		tidyCommand := exec.Command("go", "mod", "tidy")
@@ -96,7 +100,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		tidyCommand.Stdout = os.Stdout
 		tidyCommand.Stderr = os.Stderr
 		if err := tidyCommand.Run(); err != nil {
-			return changed, fmt.Errorf("Unable to run go mod tidy for %s at %s: %v", depPkg, rev, err)
+			return changed, fmt.Errorf("unable to run go mod tidy for %s at %s: %v", depPkg, rev, err)
 		}
 
 		found[dep] = true
@@ -132,14 +136,26 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commi
 
 	fmt.Printf("Packaging up pseudo version %s for %s into go mod cache.\n", pseudoVersion, depPkg)
 
+	// create the cache if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(goModFile), os.FileMode(755)); err != nil {
-		return fmt.Errorf("Unable to create %s directory: %v", cacheDir, err)
+		return fmt.Errorf("unable to create %s directory: %v", cacheDir, err)
 	}
 
+	// checkout the dep repo to the commit at the tag
+	checkoutCommand := exec.Command("git", "checkout", commit)
+	checkoutCommand.Dir = fmt.Sprintf("%s/src/%s", os.Getenv("GOPATH"), depPkg)
+	checkoutCommand.Stdout = os.Stdout
+	checkoutCommand.Stderr = os.Stderr
+	if err := checkoutCommand.Run(); err != nil {
+		return fmt.Errorf("failed to checkout %s at %s: %v", depPkg, commit, err)
+	}
+
+	// copy go.mod to pseudoVersion.mod in the cache dir
 	if err := copyFile(fmt.Sprintf("%s/go.mod", depPath), goModFile); err != nil {
-		return fmt.Errorf("Unable to copy %s file to %s to gomod cache for %s: %v", fmt.Sprintf("%s/go.mod", depPath), goModFile, depPkg, err)
+		return fmt.Errorf("unable to copy %s file to %s to gomod cache for %s: %v", fmt.Sprintf("%s/go.mod", depPath), goModFile, depPkg, err)
 	}
 
+	// create pseudoVersion.info file in the cache dir
 	moduleInfo := ModuleInfo{
 		Version: pseudoVersion,
 		Name:    commit,
@@ -149,45 +165,30 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commi
 
 	moduleFile, err := json.Marshal(moduleInfo)
 	if err != nil {
-		return fmt.Errorf("Error marshaling .info file for %s: %v", depPkg, err)
+		return fmt.Errorf("error marshaling .info file for %s: %v", depPkg, err)
 	}
 	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersion), moduleFile, 0644); err != nil {
 		return fmt.Errorf("failed to write %s file for %s: %v", fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersion), depPkg, err)
 	}
 
-	depPathPseudoVersion := fmt.Sprintf("%s@%s", depPkg, pseudoVersion)
-	zipDir := fmt.Sprintf("%s/src", os.Getenv("GOPATH"))
-	zipFile := fmt.Sprintf("%s/%s.zip", cacheDir, pseudoVersion)
-
-	// this is necessary because every file path in the zip archive must begin with <module>@<version>
-	mvCommand1 := exec.Command("mv", depPkg, depPathPseudoVersion)
-	mvCommand1.Dir = zipDir
-	if err := mvCommand1.Run(); err != nil {
-		return fmt.Errorf("Unable to mv %s to %s: %v", depPkg, depPathPseudoVersion, err)
-	}
-
-	zipCommand := exec.Command("zip", "-y", "-x", fmt.Sprintf("%s/.git/*", depPathPseudoVersion), "-q", "-r", zipFile, depPathPseudoVersion)
-	zipCommand.Dir = zipDir
+	// create the pseudoVersion.zip file in the cache dir. This zip file has the same hash
+	// as of the zip file that would have been created by go mod download.
+	zipCommand := exec.Command("/gomod-zip", "--package-name", depPkg, "--pseudo-version", pseudoVersion)
 	zipCommand.Stdout = os.Stdout
 	zipCommand.Stderr = os.Stderr
 	if err := zipCommand.Run(); err != nil {
-		return fmt.Errorf("Unable to create zip file for %s: %v", depPkg, err)
+		return fmt.Errorf("failed to run gomod-zip for %s at %s: %v", depPkg, pseudoVersion, err)
 	}
 
-	mvCommand2 := exec.Command("mv", depPathPseudoVersion, depPkg)
-	mvCommand2.Dir = zipDir
-	if err := mvCommand2.Run(); err != nil {
-		return fmt.Errorf("Unable to mv %s to %s: %v", depPathPseudoVersion, depPath, err)
-	}
-
+	// append the pseudoVersion to the list file in the cache dir
 	listFile, err := os.OpenFile(fmt.Sprintf("%s/list", cacheDir), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("Unable to open list file in %s: %v", cacheDir, err)
+		return fmt.Errorf("unable to open list file in %s: %v", cacheDir, err)
 	}
 	defer listFile.Close()
 
 	if _, err := listFile.WriteString(fmt.Sprintf("%s\n", pseudoVersion)); err != nil {
-		return fmt.Errorf("Unable to write to list file in %s: %v", cacheDir, err)
+		return fmt.Errorf("unable to write to list file in %s: %v", cacheDir, err)
 	}
 
 	return nil
@@ -215,19 +216,19 @@ func taggedCommitHashAndTime(r *gogit.Repository, tag string) (plumbing.Hash, ti
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("Unable to open %s: %v", src, err)
+		return fmt.Errorf("unable to open %s: %v", src, err)
 	}
 	defer in.Close()
 
 	out, err := os.Create(dst)
 	if err != nil {
-		return fmt.Errorf("Unable to create %s: %v", dst, err)
+		return fmt.Errorf("unable to create %s: %v", dst, err)
 	}
 	defer out.Close()
 
 	_, err = io.Copy(out, in)
 	if err != nil {
-		return fmt.Errorf("Unable to copy %s to %s: %v", src, dst, err)
+		return fmt.Errorf("unable to copy %s to %s: %v", src, dst, err)
 	}
 	return out.Close()
 }

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -55,6 +55,14 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		rev := commit.String()
 		pseudoVersion := fmt.Sprintf("v0.0.0-%s-%s", commitTime.UTC().Format("20060102150405"), rev[:12])
 
+		downloadCommand := exec.Command("go", "mod", "download")
+		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand.Stdout = os.Stdout
+		downloadCommand.Stderr = os.Stderr
+		if err := downloadCommand.Run(); err != nil {
+			return changed, fmt.Errorf("Error running go mod download for %s: %v", depPkg, err)
+		}
+
 		if err := packageDepToGoModCache(depPath, depPkg, rev, pseudoVersion, commitTime); err != nil {
 			return changed, fmt.Errorf("failed to package %s dependency: %v", depPkg, err)
 		}
@@ -75,11 +83,11 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 			return changed, fmt.Errorf("Unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersion, err)
 		}
 
-		downloadCommand := exec.Command("go", "mod", "download")
-		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
-		downloadCommand.Stdout = os.Stdout
-		downloadCommand.Stderr = os.Stderr
-		if err := downloadCommand.Run(); err != nil {
+		downloadCommand2 := exec.Command("go", "mod", "download")
+		downloadCommand2.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand2.Stdout = os.Stdout
+		downloadCommand2.Stderr = os.Stderr
+		if err := downloadCommand2.Run(); err != nil {
 			return changed, fmt.Errorf("Error running go mod download for pseudo-version %s for %s: %v", pseudoVersion, depPkg, err)
 		}
 

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -61,24 +61,32 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 
 		requireCommand := exec.Command("go", "mod", "edit", "-fmt", "-require", fmt.Sprintf("%s@%s", depPkg, pseudoVersion))
 		requireCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		requireCommand.Stdout = os.Stdout
+		requireCommand.Stderr = os.Stderr
 		if err := requireCommand.Run(); err != nil {
 			return changed, fmt.Errorf("Unable to pin %s in the require section of go.mod to %s: %v", depPkg, pseudoVersion, err)
 		}
 
 		replaceCommand := exec.Command("go", "mod", "edit", "-fmt", "-replace", fmt.Sprintf("%s=%s@%s", depPkg, depPkg, pseudoVersion))
 		replaceCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		replaceCommand.Stdout = os.Stdout
+		replaceCommand.Stderr = os.Stderr
 		if err := replaceCommand.Run(); err != nil {
 			return changed, fmt.Errorf("Unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersion, err)
 		}
 
 		downloadCommand := exec.Command("go", "mod", "download")
 		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand.Stdout = os.Stdout
+		downloadCommand.Stderr = os.Stderr
 		if err := downloadCommand.Run(); err != nil {
 			return changed, fmt.Errorf("Error running go mod download for pseudo-version %s for %s: %v", pseudoVersion, depPkg, err)
 		}
 
 		tidyCommand := exec.Command("go", "mod", "tidy")
 		tidyCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
+		tidyCommand.Stdout = os.Stdout
+		tidyCommand.Stderr = os.Stderr
 		if err := tidyCommand.Run(); err != nil {
 			return changed, fmt.Errorf("Unable to run go mod tidy for %s at %s: %v", depPkg, rev, err)
 		}
@@ -152,6 +160,8 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commi
 
 	zipCommand := exec.Command("zip", "-y", "-x", fmt.Sprintf("%s/.git/*", depPathPseudoVersion), "-q", "-r", zipFile, depPathPseudoVersion)
 	zipCommand.Dir = zipDir
+	zipCommand.Stdout = os.Stdout
+	zipCommand.Stderr = os.Stderr
 	if err := zipCommand.Run(); err != nil {
 		return fmt.Errorf("Unable to create zip file for %s: %v", depPkg, err)
 	}

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -193,11 +193,6 @@ func main() {
 			continue
 		}
 
-		// temporarily publish only alpha tags
-		if !strings.Contains(bName, "alpha") {
-			continue
-		}
-
 		// ignore old tags
 		if tag.Tagger.When.Before(time.Date(2017, 9, 1, 0, 0, 0, 0, time.UTC)) {
 			//fmt.Printf("Ignoring old tag origin/%s from %v\n", bName, tag.Tagger.When)


### PR DESCRIPTION
This PR has the following changes:

- Display the error that might occur while running a `exec.Command`.
- Run `go mod download` before packaging up a dependency _and_ before updating the require and replace directives. This will help in avoiding packaging up, when the pseudo version is the same but we don't have it in the local cache.
- Fix the git command used for pseudo version calculation (#186)
- Publish all tags, not just alpha ones.
- Add a new go binary `gomod-zip` for creating the zip file that would have the same hash as that of the zip file if it were downloaded by `go mod download`. The zip file created by gomod differs from the former:
  - there are some extra normalizations: not considering anything in vendor, making sure we don't have directories in the file archive. These can, however, still be taken care of by `-x` and `-D` options. 
  - The zip file created by go mod download has the `00-00-1980 00:00` timestamp in the file header
for all files in the zip archive. This is not a valid UNIX timestamp and cannot be set easily. This is, however, valid in MSDOS. The `archive/zip` package [uses the MSDOS version](https://github.com/golang/go/blob/e9188d1d18040bc6cb46065b2474664b8728a6df/src/archive/zip/struct.go#L239-L243) so we create the zip file using this package.
    - change the initial zip file creation to use `git archive`: [go uses this](https://github.com/golang/go/blob/55d31e16c12c38d36811bdee65ac1f7772148250/src/cmd/go/internal/modfetch/codehost/git.go#L767).
    - add basic normalizations as [done by go](https://github.com/golang/go/blob/master/src/cmd/go/internal/modfetch/coderepo.go#L497) internally. 
    - use the `archive/zip` package to re-create the zip file from that created using `git archive`.

For the record: we had to do a `GO111MODULE=on go mod clean -modcache` first to clear the old zip files in our cache. Did this through `kubectl exec`, not using this PR.

For additional context, this [slack thread](https://kubernetes.slack.com/archives/C2C40FMNF/p1560775049352100) has more details.

/hold
doesn't fix the error yet, but I figured I'll open a PR to get my latest changes in 