### PR TITLE
[WIP] sync-tags: add support for versioned imports

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -150,6 +150,7 @@ if [ -z "${SKIP_TAGS}" ]; then
                --dependencies "${DEPS}" \
                --mapping-output-file "../tag-${REPO}-{{.Tag}}-mapping" \
                --generate-godeps=${PUBLISHER_BOT_GENERATE_GODEPS:-false} \
+               --generate-versioned-imports=${PUBLISHER_BOT_GENERATE_VERSIONED_IMPORTS:-false} \
                -alsologtostderr \
                "${EXTRA_ARGS[@]-}"
     if [ "${LAST_HEAD}" != "$(git rev-parse ${LAST_BRANCH})" ]; then

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -62,6 +62,7 @@ func main() {
 	targetOrg := flag.String("target-org", "", `the target organization to publish into (e.g. "k8s-publishing-bot")`)
 	skipGodep := flag.Bool("skip-godep", false, `skip godeps installation and godeps-restore`)
 	skipDep := flag.Bool("skip-dep", false, `skip 'dep'' installation`)
+	skipVersionedImports := flag.Bool("skip-versioned-imports", false, `skip generating versioned import paths`)
 
 	flag.Usage = Usage
 	flag.Parse()
@@ -148,6 +149,10 @@ func main() {
 	}
 	if !*skipDep {
 		installDep()
+	}
+
+	if !*skipVersionedImports {
+		installMod()
 	}
 
 	cloneSourceRepo(cfg, *skipGodep)
@@ -251,4 +256,16 @@ func cloneSourceRepo(cfg config.Config, runGodepRestore bool) {
 		restoreCmd.Dir = filepath.Join(BaseRepoPath, cfg.SourceRepo)
 		run(restoreCmd)
 	}
+}
+
+func installMod() {
+	if _, err := exec.LookPath("mod"); err == nil {
+		glog.Infof("Already installed: mod")
+		return
+	}
+
+	glog.Infof("Installing github.com/marwan-at-work/mod/cmd/mod@v0.2.2 ...")
+	modInstallCmd := exec.Command("go", "get", "github.com/marwan-at-work/mod/cmd/mod@v0.2.2")
+	modInstallCmd.Env = append(os.Environ(), "GO111MODULE=on")
+	run(modInstallCmd)
 }

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -69,6 +69,7 @@ type RepositoryRules struct {
 	SkipGodeps            bool             `yaml:"skip-godeps"`
 	SkipGomod             bool             `yaml:"skip-gomod"`
 	SkipTags              bool             `yaml:"skip-tags"`
+	SkipVersionedImports  bool             `yaml:"skip-versioned-imports"`
 	Rules                 []RepositoryRule `yaml:"rules"`
 
 	// ls-files patterns like: */BUILD *.ext pkg/foo.go Makefile

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -294,6 +294,9 @@ func (p *PublisherMunger) construct() error {
 			if p.reposRules.SkipGomod {
 				cmd.Env = append(cmd.Env, "PUBLISHER_BOT_SKIP_GOMOD=true")
 			}
+			if !p.reposRules.SkipVersionedImports {
+				cmd.Env = append(cmd.Env, "PUBLISHER_BOT_GENERATE_VERSIONED_IMPORTS=true")
+			}
 			if err := p.plog.Run(cmd); err != nil {
 				return err
 			}

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -58,7 +58,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		// in case the pseudoVersion has not changed, running go mod download will help
 		// in avoiding packaging it up if the pseudoVersion has been published already
 		downloadCommand := exec.Command("go", "mod", "download")
-		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
 		downloadCommand.Stdout = os.Stdout
 		downloadCommand.Stderr = os.Stderr
 		if err := downloadCommand.Run(); err != nil {
@@ -67,40 +67,12 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 
 		// check if we have the pseudoVersion published already. if we don't, package it up
 		// and save to local mod download cache.
-		if err := packageDepToGoModCache(depPath, depPkg, rev, pseudoVersion, commitTime); err != nil {
+		if err := packageDepToGoModCache(depPath, depPkg, rev, pseudoVersion, "", commitTime); err != nil {
 			return changed, fmt.Errorf("failed to package %s dependency: %v", depPkg, err)
 		}
 
-		requireCommand := exec.Command("go", "mod", "edit", "-fmt", "-require", fmt.Sprintf("%s@%s", depPkg, pseudoVersion))
-		requireCommand.Env = append(os.Environ(), "GO111MODULE=on")
-		requireCommand.Stdout = os.Stdout
-		requireCommand.Stderr = os.Stderr
-		if err := requireCommand.Run(); err != nil {
-			return changed, fmt.Errorf("unable to pin %s in the require section of go.mod to %s: %v", depPkg, pseudoVersion, err)
-		}
-
-		replaceCommand := exec.Command("go", "mod", "edit", "-fmt", "-replace", fmt.Sprintf("%s=%s@%s", depPkg, depPkg, pseudoVersion))
-		replaceCommand.Env = append(os.Environ(), "GO111MODULE=on")
-		replaceCommand.Stdout = os.Stdout
-		replaceCommand.Stderr = os.Stderr
-		if err := replaceCommand.Run(); err != nil {
-			return changed, fmt.Errorf("unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersion, err)
-		}
-
-		downloadCommand2 := exec.Command("go", "mod", "download")
-		downloadCommand2.Env = append(os.Environ(), "GO111MODULE=on")
-		downloadCommand2.Stdout = os.Stdout
-		downloadCommand2.Stderr = os.Stderr
-		if err := downloadCommand2.Run(); err != nil {
-			return changed, fmt.Errorf("error running go mod download for pseudo-version %s for %s: %v", pseudoVersion, depPkg, err)
-		}
-
-		tidyCommand := exec.Command("go", "mod", "tidy")
-		tidyCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
-		tidyCommand.Stdout = os.Stdout
-		tidyCommand.Stderr = os.Stderr
-		if err := tidyCommand.Run(); err != nil {
-			return changed, fmt.Errorf("unable to run go mod tidy for %s at %s: %v", depPkg, rev, err)
+		if err := updateGoModAndGoSum(depPkg, pseudoVersion, ""); err != nil {
+			return changed, err
 		}
 
 		found[dep] = true
@@ -123,18 +95,21 @@ type ModuleInfo struct {
 	Time    string
 }
 
-func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commitTime time.Time) error {
+func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag, majorVersion string, commitTime time.Time) error {
 	cacheDir := fmt.Sprintf("%s/pkg/mod/cache/download/%s/@v", os.Getenv("GOPATH"), depPkg)
-	goModFile := fmt.Sprintf("%s/%s.mod", cacheDir, pseudoVersion)
+	if majorVersion != "" {
+		cacheDir = fmt.Sprintf("%s/pkg/mod/cache/download/%s/v%s/@v", os.Getenv("GOPATH"), depPkg, majorVersion)
+	}
+	goModFile := fmt.Sprintf("%s/%s.mod", cacheDir, pseudoVersionOrTag)
 
 	if _, err := os.Stat(goModFile); err == nil {
-		fmt.Printf("Pseudo version %s for %s is already packaged up.\n", pseudoVersion, depPkg)
+		fmt.Printf("%s for %s is already packaged up.\n", pseudoVersionOrTag, depPkg)
 		return nil
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("Could not check if %s exists: %v", goModFile, err)
 	}
 
-	fmt.Printf("Packaging up pseudo version %s for %s into go mod cache.\n", pseudoVersion, depPkg)
+	fmt.Printf("Packaging up %s for %s into go mod cache.\n", pseudoVersionOrTag, depPkg)
 
 	// create the cache if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(goModFile), os.FileMode(755)); err != nil {
@@ -150,14 +125,14 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commi
 		return fmt.Errorf("failed to checkout %s at %s: %v", depPkg, commit, err)
 	}
 
-	// copy go.mod to pseudoVersion.mod in the cache dir
+	// copy go.mod to the cache dir
 	if err := copyFile(fmt.Sprintf("%s/go.mod", depPath), goModFile); err != nil {
 		return fmt.Errorf("unable to copy %s file to %s to gomod cache for %s: %v", fmt.Sprintf("%s/go.mod", depPath), goModFile, depPkg, err)
 	}
 
-	// create pseudoVersion.info file in the cache dir
+	// create info file in the cache dir
 	moduleInfo := ModuleInfo{
-		Version: pseudoVersion,
+		Version: pseudoVersionOrTag,
 		Name:    commit,
 		Short:   commit[:12],
 		Time:    commitTime.UTC().Format("2006-01-02T15:04:05Z"),
@@ -167,28 +142,88 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersion string, commi
 	if err != nil {
 		return fmt.Errorf("error marshaling .info file for %s: %v", depPkg, err)
 	}
-	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersion), moduleFile, 0644); err != nil {
-		return fmt.Errorf("failed to write %s file for %s: %v", fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersion), depPkg, err)
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersionOrTag), moduleFile, 0644); err != nil {
+		return fmt.Errorf("failed to write %s file for %s: %v", fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersionOrTag), depPkg, err)
 	}
 
-	// create the pseudoVersion.zip file in the cache dir. This zip file has the same hash
+	// create the zip file in the cache dir. This zip file has the same hash
 	// as of the zip file that would have been created by go mod download.
-	zipCommand := exec.Command("/gomod-zip", "--package-name", depPkg, "--pseudo-version", pseudoVersion)
+	zipCmd := []string{"/gomod-zip", "--package-name", depPkg, "--pseudo-version", pseudoVersionOrTag}
+	if majorVersion != "" {
+		zipCmd = append(zipCmd, "--major-version", majorVersion)
+	}
+	zipCommand := exec.Command(zipCmd[0], zipCmd[1:]...)
 	zipCommand.Stdout = os.Stdout
 	zipCommand.Stderr = os.Stderr
 	if err := zipCommand.Run(); err != nil {
-		return fmt.Errorf("failed to run gomod-zip for %s at %s: %v", depPkg, pseudoVersion, err)
+		return fmt.Errorf("failed to run gomod-zip for %s at %s: %v", depPkg, pseudoVersionOrTag, err)
 	}
 
-	// append the pseudoVersion to the list file in the cache dir
+	// append the pseudoVersion/tag to the list file in the cache dir
 	listFile, err := os.OpenFile(fmt.Sprintf("%s/list", cacheDir), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("unable to open list file in %s: %v", cacheDir, err)
 	}
 	defer listFile.Close()
 
-	if _, err := listFile.WriteString(fmt.Sprintf("%s\n", pseudoVersion)); err != nil {
+	if _, err := listFile.WriteString(fmt.Sprintf("%s\n", pseudoVersionOrTag)); err != nil {
 		return fmt.Errorf("unable to write to list file in %s: %v", cacheDir, err)
+	}
+
+	return nil
+}
+
+func updateGoModAndGoSum(depPkg, pseudoVersionOrTag, majorVersion string) error {
+	requireDirective := fmt.Sprintf("%s@%s", depPkg, pseudoVersionOrTag)
+	if majorVersion != "" {
+		requireDirective = fmt.Sprintf("%s/v%s@%s", depPkg, majorVersion, pseudoVersionOrTag)
+	}
+
+	requireCommand := exec.Command("go", "mod", "edit", "-fmt", "-require", requireDirective)
+	requireCommand.Env = append(os.Environ(), "GO111MODULE=on")
+	requireCommand.Stdout = os.Stdout
+	requireCommand.Stderr = os.Stderr
+	if err := requireCommand.Run(); err != nil {
+		return fmt.Errorf("unable to pin %s in the require section of go.mod to %s: %v", depPkg, pseudoVersionOrTag, err)
+	}
+
+	replaceDirective := fmt.Sprintf("%s=%s@%s", depPkg, depPkg, pseudoVersionOrTag)
+	if majorVersion != "" {
+		replaceDirective = fmt.Sprintf("%s/v%s=%s/v%s@%s", depPkg, majorVersion, depPkg, majorVersion, pseudoVersionOrTag)
+	}
+
+	replaceCommand := exec.Command("go", "mod", "edit", "-fmt", "-replace", replaceDirective)
+	replaceCommand.Env = append(os.Environ(), "GO111MODULE=on")
+	replaceCommand.Stdout = os.Stdout
+	replaceCommand.Stderr = os.Stderr
+	if err := replaceCommand.Run(); err != nil {
+		return fmt.Errorf("unable to pin %s in the replace section of go.mod to %s: %v", depPkg, pseudoVersionOrTag, err)
+	}
+
+	if majorVersion != "" {
+		dropReplaceCommmand := exec.Command("go", "mod", "edit", "-fmt", "-dropreplace", depPkg)
+		dropReplaceCommmand.Env = append(os.Environ(), "GO111MODULE=on")
+		dropReplaceCommmand.Stdout = os.Stdout
+		dropReplaceCommmand.Stderr = os.Stderr
+		if err := dropReplaceCommmand.Run(); err != nil {
+			return fmt.Errorf("unable to drop %s from the replace section of go.mod: %v", depPkg, err)
+		}
+	}
+
+	downloadCommand := exec.Command("go", "mod", "download")
+	downloadCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
+	downloadCommand.Stdout = os.Stdout
+	downloadCommand.Stderr = os.Stderr
+	if err := downloadCommand.Run(); err != nil {
+		return fmt.Errorf("error running go mod download for %s for %s: %v", pseudoVersionOrTag, depPkg, err)
+	}
+
+	tidyCommand := exec.Command("go", "mod", "tidy")
+	tidyCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
+	tidyCommand.Stdout = os.Stdout
+	tidyCommand.Stderr = os.Stderr
+	if err := tidyCommand.Run(); err != nil {
+		return fmt.Errorf("unable to run go mod tidy for %s at %s: %v", depPkg, pseudoVersionOrTag, err)
 	}
 
 	return nil

--- a/cmd/sync-tags/versioned_imports.go
+++ b/cmd/sync-tags/versioned_imports.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	gogit "gopkg.in/src-d/go-git.v4"
+)
+
+// generateVersionedImportsWithTaggedDependencies updates import paths of all
+// dependencies to versioned import paths using the majorVersion.
+// It also updates go.mod and go.sum to point these dependencies to the given tag.
+func generateVersionedImportsWithTaggedDependencies(majorVersion, tag string, depsRepo []string) error {
+	updated := map[string]bool{}
+
+	for _, dep := range depsRepo {
+		depPath := filepath.Join("..", dep)
+		dr, err := gogit.PlainOpen(depPath)
+		if err != nil {
+			return fmt.Errorf("failed to open dependency repo at %q: %v", depPath, err)
+		}
+
+		depPkg, err := fullPackageName(depPath)
+		if err != nil {
+			return fmt.Errorf("failed to get package at %s: %v", depPath, err)
+		}
+
+		commit, commitTime, err := taggedCommitHashAndTime(dr, tag)
+		if err != nil {
+			return fmt.Errorf("failed to get tag %s for %q: %v", tag, depPkg, err)
+		}
+		rev := commit.String()
+
+		// if the dependency was already published at this tag, go mod download will help
+		// in avoiding packaging it up again
+		downloadCommand := exec.Command("go", "mod", "download")
+		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
+		downloadCommand.Stdout = os.Stdout
+		downloadCommand.Stderr = os.Stderr
+		if err := downloadCommand.Run(); err != nil {
+			return fmt.Errorf("error running go mod download for %s: %v", depPkg, err)
+		}
+
+		// check if we have the tag published already. if we don't, package it up
+		// and save to local mod download cache.
+		if err := packageDepToGoModCache(depPath, depPkg, rev, tag, majorVersion, commitTime); err != nil {
+			return fmt.Errorf("failed to package %s dependency: %v", depPkg, err)
+		}
+
+		// update import paths for the dependency
+		depUpgradeCmd := exec.Command("mod", "upgrade", "-t", majorVersion, "-mod-name", depPkg)
+		depUpgradeCmd.Env = append(os.Environ(), "GO111MODULE=on", "GOPOXY=file://${GOPATH}/pkg/mod/cache/download")
+		depUpgradeCmd.Stdout = os.Stdout
+		depUpgradeCmd.Stderr = os.Stderr
+		if err := depUpgradeCmd.Run(); err != nil {
+			return fmt.Errorf("unable to upgrade %s to v%s: %v", dep, majorVersion, err)
+		}
+		fmt.Printf("Updated import paths for %s to major version v%s.\n", dep, majorVersion)
+
+		// update go.mod and go.sum to point the dependency at the tag
+		if err := updateGoModAndGoSum(depPkg, tag, majorVersion); err != nil {
+			return err
+		}
+
+		updated[dep] = true
+	}
+
+	for _, dep := range depsRepo {
+		if !updated[dep] {
+			fmt.Printf("Warning: dependency %s was not updated.\n", dep)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds support for tagging a version which contains versioned imports. For `v1.15.1` of k/k, two versions will be published:
- `kubernetes-1.15.1` - this tag will _not_ contain versioned imports, and will instead rely on pseudo versions (existing behaviour).
- `v15.0.1` - this new tag will contain versioned imports.

To update import paths, this uses https://github.com/marwan-at-work/mod. `mod` is also "officially" suggested in the [go modules wiki](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher). We use the `v0.2.2` version of this tool because we need https://github.com/marwan-at-work/mod/pull/8 for it to work.

Overall, we do the following:

- Update the import paths containing the current module and update the module name in `go.mod`.
- If the repo has dependencies, we then do the following for each dependency:
  - Fake-publish/package the dependency at the new tag to the local go mod cache.
  - Update all import paths containing this dependency.
  - Add require and replace directives for the new tag, and `dropreplace` the old pseudoversion.
  - Run `go mod tidy`. This drops the old require directives and updates `go.sum`.


An example run of this can be seen at [apimachinery@v15.0.0](https://github.com/prowtest/apimachinery/tree/v15.0.0), [api@v15.0.0](https://github.com/prowtest/api/tree/v15.0.0), [client-go@v15.0.0](https://github.com/prowtest/client-go/tree/v15.0.0).

/cc @sttts @liggitt @dims 
/assign @sttts 