### PR TITLE
Use gcr.io/k8s-staging-publishing-bot for storing image

### DIFF
--- a/configs/kubernetes
+++ b/configs/kubernetes
@@ -1,4 +1,4 @@
-DOCKER_REPO = sttts/k8s-publishing-bot
+DOCKER_REPO = gcr.io/k8s-staging-publishing-bot/k8s-publishing-bot
 NAMESPACE = k8s-publishing-bot
 SCHEDULE = * */4 * * *
 INTERVAL = 14400


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/pull/282

Will redeploy once this gets merged.

Note: we will have to repush the image every 2 months or so (https://github.com/kubernetes/k8s.io/pull/297). Something tells me that we'll end up doing that anyway. :upside_down_face: 

/assign @sttts @dims 