### PR TITLE
Bump default Go version to 1.12.8

### DIFF
--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const defaultGoVersion = "1.12.7"
+const defaultGoVersion = "1.12.8"
 
 // installGoVersions download and unpacks the specified Golang versions to $GOPATH/
 func InstallDefaultGoVersion() error {


### PR DESCRIPTION
Bump default Go version to 1.12.8

Ref: https://github.com/kubernetes/kubernetes/issues/79912

/assign @sttts 