### PR TITLE
Bump default Go version to 1.12.9

### DIFF
--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const defaultGoVersion = "1.12.8"
+const defaultGoVersion = "1.12.9"
 
 // installGoVersions download and unpacks the specified Golang versions to $GOPATH/
 func InstallDefaultGoVersion() error {


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

ref: https://github.com/kubernetes/kubernetes/pull/81489