### PR TITLE
Use proxy.golang.org for go mod download

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -857,7 +857,7 @@ update-deps-in-gomod() {
 
     GO111MODULE=on go mod edit -json | jq -r '.Replace[]? | select(.New.Path | startswith("../")) | "-dropreplace \(.Old.Path)"' | GO111MODULE=on xargs -L 100 go mod edit -fmt
     
-    GO111MODULE=on go mod download
+    GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
     GOPROXY="file://${GOPATH}/pkg/mod/cache/download" GO111MODULE=on go mod tidy
 
     git add go.mod go.sum
@@ -921,7 +921,7 @@ checkout-deps-to-kube-commit() {
             git checkout -q "${dep_commit}"
 
             echo "Downloading go mod dependencies..."
-            GO111MODULE=on go mod download
+            GO111MODULE=on GOPROXY=https://proxy.golang.org go mod download
 
             local pseudo_version=$(gomod-pseudo-version)
             local cache_dir="${GOPATH}/pkg/mod/cache/download/${base_package}/${dep}/@v"

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -58,7 +58,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		// in case the pseudoVersion has not changed, running go mod download will help
 		// in avoiding packaging it up if the pseudoVersion has been published already
 		downloadCommand := exec.Command("go", "mod", "download")
-		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on", "GOPROXY=https://proxy.golang.org")
 		downloadCommand.Stdout = os.Stdout
 		downloadCommand.Stderr = os.Stderr
 		if err := downloadCommand.Run(); err != nil {
@@ -88,7 +88,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string) (bool, err
 		}
 
 		downloadCommand2 := exec.Command("go", "mod", "download")
-		downloadCommand2.Env = append(os.Environ(), "GO111MODULE=on")
+		downloadCommand2.Env = append(os.Environ(), "GO111MODULE=on", "GOPROXY=https://proxy.golang.org")
 		downloadCommand2.Stdout = os.Stdout
 		downloadCommand2.Stderr = os.Stderr
 		if err := downloadCommand2.Run(); err != nil {


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/83761

If a dependency is re-tagged after the dependency is updated in k/k, the
hash in go.sum in k/k will point to the old tag.

When we run `go mod download` in the publishing-bot, the bot currently
downloads directly from github.com. Since the dependency was re-tagged,
the downloaded hash points to the new tag and is no longer equal to
the old hash in go.sum. This leads to a "checksum mismatch error".

Reverting the bad dependency update in k/k won't help with the
publishing-bot because we check if go.mod needs update after each commit.

To fix the bot while encountering such "bad" changes, this commit uses
proxy.golang.org as GOPROXY while running `go mod download` since
proxy.golang.org caches content and the old hash still exists there.

Note: proxy.golang.org is also used in the CI for k/k, which ensures
that the verify job remains green in case of such re-tagging.

/cc @sttts @dims @liggitt 
/assign @sttts 