### PR TITLE
Bump default Go version to 1.13.4

### DIFF
--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const defaultGoVersion = "1.12.9"
+const defaultGoVersion = "1.13.4"
 
 // installGoVersions download and unpacks the specified Golang versions to $GOPATH/
 func InstallDefaultGoVersion() error {


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/82809

/assign @sttts 