### PR TITLE
Use gcr.io/k8s-staging-publishing-bot for nightly

### DIFF
--- a/configs/kubernetes-nightly
+++ b/configs/kubernetes-nightly
@@ -1,4 +1,4 @@
-DOCKER_REPO = sttts/k8s-publishing-bot-nightly
+DOCKER_REPO = gcr.io/k8s-staging-publishing-bot/k8s-publishing-bot-nightly
 NAMESPACE = k8s-publishing-bot-nightly
 SCHEDULE = * */4 * * *
 INTERVAL = 14400


### PR DESCRIPTION
If we use `sttts/k8s-publishing-bot-nightly`, @sttts would need to push the image everytime.

/hold
I'm not sure if we want to have the nightly version in the "official" gcr staging repo, so adding an explicit hold for this. If we don't want to have it there, we can always specify a personal docker repo while deploying the nightly bot too.

/assign @dims @sttts 
fyi @liggitt 