### PR TITLE
sync-tags: on volume recreation tags might only exist as origin/<tag>

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM debian:stretch
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.11.0-3+deb9u4 \
+ && apt-get install -y -qq git=1:2.11.0-3+deb9u5 \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -54,7 +54,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string, semverTag 
 			return changed, fmt.Errorf("failed to get package at %s: %v", depPath, err)
 		}
 
-		commit, commitTime, err := taggedCommitHashAndTime(dr, tag)
+		commit, commitTime, err := localOrPublishedTaggedCommitHashAndTime(dr, tag)
 		if err != nil {
 			return changed, fmt.Errorf("failed to get tag %s for %q: %v", tag, depPkg, err)
 		}
@@ -219,6 +219,13 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag string, 
 	}
 
 	return nil
+}
+
+func localOrPublishedTaggedCommitHashAndTime(r *gogit.Repository, tag string) (plumbing.Hash, time.Time, error) {
+	if commit, commitTime, err := taggedCommitHashAndTime(r, tag); err == nil {
+		return commit, commitTime, nil
+	}
+	return taggedCommitHashAndTime(r, "origin/"+tag)
 }
 
 func taggedCommitHashAndTime(r *gogit.Repository, tag string) (plumbing.Hash, time.Time, error) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/publishing-bot/issues/217.