### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@
 FROM debian:stretch
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.11.0-3+deb9u5 \
- && apt-get install -y -qq mercurial \
- && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
+ && apt-get --no-install-recommends install -y -qq git=1:2.11.0-3+deb9u5 \
+ && apt-get --no-install-recommends install -y -qq mercurial \
+ && apt-get --no-install-recommends install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH="/go-workspace"


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .