### PR TITLE
Remove note about godeps instance of the bot

### DIFF
--- a/k8s-publishing-bot.md
+++ b/k8s-publishing-bot.md
@@ -1,19 +1,10 @@
 # Kubernetes Publishing Bot
 
-The publishing-bot for the Kubernetes project is running on a CNCF sponsored
-GKE cluster `development2` in the `kubernetes-public` project.
+The publishing-bot for the Kubernetes project is running in the
+`k8s-publishing-bot` namespace  on a CNCF sponsored GKE cluster
+`development2` in the `kubernetes-public` project.
 
-The bot is responsible for updating `go.mod`/`Godeps` and `vendor` for target repos.
-To support both godeps for releases <= v1.14 and go modules for the master branch
-and releases >= v1.14, we run two instances of the bot today.
-
-The instance of the bot responsible for syncing releases <= v1.14 runs in the
-`k8s-publishing-bot-godeps` namespace and the instance of the bot responsible
-for syncing the master branch and releases >= v1.14 runs in the ` k8s-publishing-bot`
-namespace.
-
-The code for the former can be found in the [godeps branch] and the latter in the master
-branch of the publishing-bot repo.
+The bot is responsible for updating `go.mod`/`Godeps` for target repos.
 
 ## Permissions
 
@@ -38,6 +29,5 @@ hack/fetch-all-latest-and-push.sh kubernetes
 make validate build-image push-image deploy CONFIG=configs/kubernetes
 ```
 
-[godeps branch]: https://github.com/kubernetes/publishing-bot/tree/godeps
 [k8s-infra-cluster-admins]: https://groups.google.com/forum/#!forum/k8s-infra-cluster-admins
 [groups.yaml]: https://git.k8s.io/k8s.io/groups/groups.yaml


### PR DESCRIPTION
The godeps instance of the bot has now been removed. This instance was
only used for Kubernetes versions <=1.14, which are not
supported anymore.

The final patch release for 1.14 was in early December, so we can now be
sure that we don't need this instance anymore.

/assign @dims 