### PR TITLE
hack: add controller-manager and mount-utils repo

### DIFF
--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -43,6 +43,7 @@ repos=(
     cluster-bootstrap
     code-generator
     component-base
+    controller-manager
     cri-api
     csi-api
     csi-translation-lib

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -55,6 +55,7 @@ repos=(
     kube-scheduler
     legacy-cloud-providers
     metrics
+    mount-utils
     node-api
     sample-apiserver
     sample-cli-plugin


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/1895 (PR to add staging dir at https://github.com/kubernetes/kubernetes/pull/91354)

/hold
until https://github.com/kubernetes/kubernetes/pull/91354 and https://github.com/kubernetes/test-infra/pull/17712 have merged

/assign @dims 