### PR TITLE
scripts: update sed separator to be `,`

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -851,7 +851,7 @@ update-deps-in-gomod() {
     # if dependencies exist, dep_packages is a comma separated list of {base_package}/{dep}. Eg: "k8s.io/api,k8s.io/apimachinery"
     local dep_packages=""
     if [ "$dep_count" != 0 ]; then
-      dep_packages="$(echo ${1} | tr "," "\n" | sed -e 's/:.*//' -e s/^/"${base_package}\/"/ | paste -sd "," -)"
+      dep_packages="$(echo ${1} | tr "," "\n" | sed -e 's/:.*//' -e s,^,"${base_package}/", | paste -sd "," -)"
     fi
 
     for (( i=0; i<${dep_count}; i++ )); do
@@ -902,7 +902,7 @@ checkout-deps-to-kube-commit() {
     # if dependencies exist, dep_packages is a comma separated list of {base_package}/{dep}. Eg: "k8s.io/api,k8s.io/apimachinery"
     local dep_packages=""
     if [ "$dep_count" != 0 ]; then
-      dep_packages="$(echo ${2} | tr "," "\n" | sed -e 's/:.*//' -e s/^/"${base_package}\/"/ | paste -sd "," -)"
+      dep_packages="$(echo ${2} | tr "," "\n" | sed -e 's/:.*//' -e s,^,"${base_package}/", | paste -sd "," -)"
     fi
 
     # get last k8s.io/kubernetes commit on HEAD ...


### PR DESCRIPTION
`sed -s /^/"${base_package}\/"/` only works when there is no `/`
in `${base_package}`. While this is true for `k8s.io`, this is not
necessary true for downstream repositories.

Here is the error message when `${base_package}` is `tess.io/ebay`:

```console
        ++ echo api:master
        ++ tr , '\n'
        ++ sed -e 's/:.*//' -e 's/^/tess.io/ebay\//'
        ++ paste -sd , -
        sed: -e expression #2, char 14: unknown option to `s'
        + dep_packages=
E0601 19:23:26.812345      12 publisher.go:413] exit status 1
I0601 19:23:26.815109      12 main.go:202] Failed to run publisher: exit status 1
```

Fixes #225.