### PR TITLE
Bump default go version to 1.14.4

### DIFF
--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const defaultGoVersion = "1.13.4"
+const defaultGoVersion = "1.14.4"
 
 // installGoVersions download and unpacks the specified Golang versions to $GOPATH/
 func InstallDefaultGoVersion() error {


### PR DESCRIPTION
Ref:
- https://github.com/kubernetes/kubernetes/pull/88638 updated go to 1.14.4
- https://github.com/kubernetes/kubernetes/pull/92438 contains fixups to move to 1.14.4

I have created https://github.com/kubernetes/publishing-bot/issues/229 to track moving `defaultGoVersion` to the rules file and will work on it after this PR gets merged. I'd prefer merging this for now to fix the bot (it broke down because some repos now require 1.14 specific code):

```
[24 Jun 20 05:55 UTC]: Running smoke tests for branch master
[24 Jun 20 05:55 UTC]: /bin/bash -xec "# assumes GO111MODULE=on\ngo build .\n"
	+ go build .
	# k8s.io/component-base/cli/flag
	../../../pkg/mod/k8s.io/component-base@v0.0.0-20200624053949-32266bec4512/cli/flag/ciphersuites_flag.go:51:51: undefined: tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
	../../../pkg/mod/k8s.io/component-base@v0.0.0-20200624053949-32266bec4512/cli/flag/ciphersuites_flag.go:52:51: undefined: tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
	note: module requires Go 1.14
[24 Jun 20 05:56 UTC]: exit status 2
    	+ go build .
    	# k8s.io/component-base/cli/flag
    	../../../pkg/mod/k8s.io/component-base@v0.0.0-20200624053949-32266bec4512/cli/flag/ciphersuites_flag.go:51:51: undefined: tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
    	../../../pkg/mod/k8s.io/component-base@v0.0.0-20200624053949-32266bec4512/cli/flag/ciphersuites_flag.go:52:51: undefined: tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
    	note: module requires Go 1.14
```