### PR TITLE
Move default go version to rules file

### DIFF
--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -29,16 +29,24 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const defaultGoVersion = "1.14.4"
+// deprecatedDefaultGoVersion hardcodes the (old) default go version.
+// The right way to define the default go version today is to specify in rules.
+// TODO(nikhita): remove deprecatedDefaultGoVersion when go 1.16 is released.
+var deprecatedDefaultGoVersion = "1.14.4"
 
-// installGoVersions download and unpacks the specified Golang versions to $GOPATH/
-func InstallDefaultGoVersion() error {
-	var empty config.RepositoryRules
-	return InstallGoVersions(&empty)
-}
-
-// installGoVersions download and unpacks the specified Golang versions to $GOPATH/
+// InstallGoVersions download and unpacks the specified Golang versions to $GOPATH/
+// If the DefaultGoVersion is not specfied in rules, it defaults to 1.14.4.
 func InstallGoVersions(rules *config.RepositoryRules) error {
+	if rules == nil {
+		return nil
+	}
+
+	defaultGoVersion := deprecatedDefaultGoVersion
+	if rules.DefaultGoVersion != nil {
+		defaultGoVersion = *rules.DefaultGoVersion
+	}
+	glog.Infof("Using %s as the default go version", defaultGoVersion)
+
 	goVersions := []string{defaultGoVersion}
 	for _, rule := range rules.Rules {
 		for _, branch := range rule.Branches {


### PR DESCRIPTION
Today, the `defaultGoVersion` is hardcoded in the publishing-bot. This
means that whenever k/k undergoes a go version bump, we need to manually
update the hardcoded version in the bot.

To ensure that we can bump the go version for publishing-bot along with
other places in k/k, this commit moves `defaultGoVersion` to the rules
file.

This commit introduces the following changes:

- A new optional field `default-go-version` is introduced in the rules
file.

- To avoid breaking existing users, if the `default-go-version` field is
not specified in the rules file, the bot defaults to
`deprecatedDefaultGoVersion` (go 1.14.4). Since go stops supporting
Go 1.x once Go 1.x+2 is released, the defaulting to
`deprecatedDefaultGoVersion` will be removed once go 1.16 is released
and users will be required to specify the `default-go-version` field.

- We now validate that all go versions specified are valid semver
versions.

- Installation of the default go version is moved from `init-repo`
to the `publishing-bot` binary. This is needed because we need to update
the source repo and read the rules file in [`Run()`](https://github.com/kubernetes/publishing-bot/blob/4437c32dbde906dd4a9d7ab2ca0cea6b72dc6146/cmd/publishing-bot/publisher.go#L393-L421) (in publisher.go)
before installing the defaultGoVersion.

- `init-repo` no longer installs godep and dep. We moved away from
godep and dep a long time ago. We use [`godeps-gen`](https://github.com/kubernetes/publishing-bot/blob/master/cmd/godeps-gen/main.go) to generate
the fake Godeps.json file but the Godeps.json file in this case is
generated by manipulating the file directly, and not by using the `godep`
binary.