### PR TITLE
Skip checkout of deps if their look-up table is empty

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -531,7 +531,7 @@ sync_repo() {
         /collapsed-kube-commit-mapper --commit-message-tag $(echo ${source_repo_name} | sed 's/^./\L\u&/')-commit --source-branch refs/heads/upstream-branch > ../kube-commits-${repo}-${dst_branch}
     else
         echo "No merge commit on ${dst_branch} branch, must be old. Skipping look-up table."
-        echo > ../kube-commits-${repo}-${dst_branch}
+        touch ../kube-commits-${repo}-${dst_branch}
     fi
 }
 
@@ -919,6 +919,11 @@ checkout-deps-to-kube-commit() {
     for (( i=0; i<${dep_count}; i++ )); do
         local dep="${deps[i]%%:*}"
         local branch="${deps[i]##*:}"
+
+       if ! [ -s ../kube-commits-${dep}-${branch} ]; then
+           echo "Skipping checking out k8s.io/${dep} since its look-up table is empty."
+           continue
+       fi
 
         echo "Looking up which commit in the ${branch} branch of k8s.io/${dep} corresponds to k8s.io/kubernetes commit ${k_last_kube_merge}."
         local k_commit=""


### PR DESCRIPTION
If a dependency's look-up table is empty, we will get an error while
trying to read the `kube-commits-${dep}-${branch}` file.

To avoid getting this error, this commit adds a check for the file size
before reading the file.

---

Note to self -  a dependency's look-up table can be empty if it does
not have merge commits in the filtered branch.

This case is possible because:

- `git filter branch` drops fast-forward merges which don't contain
diffs.
- While constructing the tree to create the dropped merge commit, it is
possible that the second parent of the merge commit is also `HEAD`
of the filtered branch. Since both parents would be then be `HEAD`,
we end up with a tree with no merge commits as first parents.