### PR TITLE
Always create lookup-up table for source-to-dst mapping

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -526,13 +526,8 @@ sync_repo() {
 
     # create look-up file for collapsed upstream commits
     local repo=$(basename ${PWD})
-    if [ -n "$(git log --oneline --first-parent --merges | head -n 1)" ]; then
-        echo "Writing k8s.io/kubernetes commit lookup table to ../kube-commits-${repo}-${dst_branch}"
-        /collapsed-kube-commit-mapper --commit-message-tag $(echo ${source_repo_name} | sed 's/^./\L\u&/')-commit --source-branch refs/heads/upstream-branch > ../kube-commits-${repo}-${dst_branch}
-    else
-        echo "No merge commit on ${dst_branch} branch, must be old. Skipping look-up table."
-        touch ../kube-commits-${repo}-${dst_branch}
-    fi
+    echo "Writing k8s.io/kubernetes commit lookup table to ../kube-commits-${repo}-${dst_branch}"
+    /collapsed-kube-commit-mapper --commit-message-tag $(echo ${source_repo_name} | sed 's/^./\L\u&/')-commit --source-branch refs/heads/upstream-branch > ../kube-commits-${repo}-${dst_branch}
 }
 
 # for some PR branches cherry-picks fail. Put commits here where we only pick the whole merge as a single commit.
@@ -919,11 +914,6 @@ checkout-deps-to-kube-commit() {
     for (( i=0; i<${dep_count}; i++ )); do
         local dep="${deps[i]%%:*}"
         local branch="${deps[i]##*:}"
-
-       if ! [ -s ../kube-commits-${dep}-${branch} ]; then
-           echo "Skipping checking out k8s.io/${dep} since its look-up table is empty."
-           continue
-       fi
 
         echo "Looking up which commit in the ${branch} branch of k8s.io/${dep} corresponds to k8s.io/kubernetes commit ${k_last_kube_merge}."
         local k_commit=""


### PR DESCRIPTION
Currently, after running `git filter-branch` and constructing dropped
fast-forward merges, we check if there are merge commits in this new
list of commits. Only if there are merge commits, we construct the
look-up table for mapping k/k mainline commits to destination commits.

However, it is not necessary that this new filtered list of commits
should have merge commits. The mapping is from **_k/k's merge commits_** to
first parent commits in the destination repo. The only requirement is
that k/k should have merge commits, requiring merge commits in the
destination repo is not necessary.

We also always need the look-up table to update go.mod files if a repo
is a dependency to another staging repo. The look-up table is also needed
to figure out which commit should be tagged.

We unconditionally create the look-up table while tagging so there are
no errors while running `sync-tags`.

---

Note on why destination commits might not have a merge commit:

After running `git filter-branch`, we construct the git tree using
`git commit-tree -p <parent1> <parent2>` for including dropped
fast-forward merges. Both parents can be equal if the parent is also
the `HEAD` commit. In this case, the dropped fast-forward merge has a
single parent and isn't a "merge commit" in git's sense of the world.

If a repo's "merge commits" are all created using the above method,
it means that `git log --oneline --first-parent --merges` won't return
anything.

