### PR TITLE
sync-tags: update deps only if go.mod exists at tag

### DIFF
--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -299,17 +299,17 @@ func main() {
 			}
 		}
 
-		// update go.mod or Godeps.json to point to actual tagged version in the dependencies. This version might differ
-		// from the one currently in go.mod  or Godeps.json because the other repo could have gotten more commit for this
-		// tag, but this repo didn't. Compare https://github.com/kubernetes/publishing-bot/issues/12 for details.
-		var changed, goModExists bool
-		_, err = os.Stat("go.mod")
-		if err == nil {
-			goModExists = true
-		}
-
 		if len(dependentRepos) > 0 {
 			wt := checkoutBranchTagCommit(r, bh, dependentRepos)
+
+			// update go.mod or Godeps.json to point to actual tagged version in the dependencies. This version might differ
+			// from the one currently in go.mod  or Godeps.json because the other repo could have gotten more commit for this
+			// tag, but this repo didn't. Compare https://github.com/kubernetes/publishing-bot/issues/12 for details.
+			var changed, goModExists bool
+			_, err = os.Stat("go.mod")
+			if err == nil {
+				goModExists = true
+			}
 
 			// if go.mod exists, fix only go.mod and generate Godeps.json from it later
 			// if it doesn't exist, check if Godeps.json exists, and update it


### PR DESCRIPTION
In sync-tags, we try to publish corresponding tags for ALL tags in
k/k. This means that even if the repo didn't exist at an old
tag like `v0.10.0-alpha.0`, we still try to publish it.

If the repo is new and has no dependencies, then the published tag
`v0.10.0-alpha.0` will point to an empty repo with an initial
empty commit.
Example - https://github.com/kubernetes/mount-utils/tree/v0.10.0-alpha.0

However, if a repo is new AND has dependencies, we will also try
to update deps in go.mod to point to `v0.10.0-alpha.0`.
But since the repo is empty at this tag, `go mod download` fails
with:

```
go mod download: no modules specified (see 'go help mod download')
```

To fix the error, we need to update go.mod only if the go.mod file
exists.

This commit moves the check for existence of go.mod to _after_
checking out repo to the tag. Before this commit, we checked for the
existence of go.mod but _before_ checking out the repo, which isn't
accurate.