### PR TITLE
Fix build image error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM debian:stretch
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.11.0-3+deb9u5 \
+ && apt-get install -y -qq git \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

Error:
```
Step 3/20 : RUN apt-get update  && apt-get install -y -qq git=1:2.11.0-3+deb9u5  && apt-get install -y -qq mercurial  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip  && rm -rf /var/lib/apt/lists/*
 ---> Running in 5b460e778d76
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [53.0 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://deb.debian.org/debian stretch Release.gpg [2410 B]
Get:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [610 kB]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages [2596 B]
Get:8 http://deb.debian.org/debian stretch/main amd64 Packages [7080 kB]
Fetched 7959 kB in 1s (4819 kB/s)
Reading package lists...
E: Version '1:2.11.0-3+deb9u5' for 'git' was not found

```

Now git version has upgrade as deb9u7:
```
root:[publishing-bot]$ docker run -it --rm debian:stretch bash -c "apt update && apt search '^git$'"
Get:1 http://security.debian.org/debian-security stretch/updates InRelease [53.0 kB]
Ign:2 http://deb.debian.org/debian stretch InRelease
Get:3 http://deb.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://deb.debian.org/debian stretch Release.gpg [2410 B]
Get:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [610 kB]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages [2596 B]
Get:8 http://deb.debian.org/debian stretch/main amd64 Packages [7080 kB]
Fetched 7959 kB in 1s (4860 kB/s)
Reading package lists... Done
Building dependency tree
Reading state information... Done
All packages are up to date.
Sorting... Done
Full Text Search... Done
git/oldstable,oldstable 1:2.11.0-3+deb9u7 amd64
  fast, scalable, distributed revision control system

```