### PR TITLE
update regex to match some special case (ie 1.15.10)

### DIFF
--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -168,7 +168,7 @@ func validateGoVersions(rules *RepositoryRules) (errs []error) {
 // go versions don't follow semver. Examples:
 // 1. 1.15.0 is invalid, 1.15 is valid
 // 2. 1.15.0-rc.1 is invalid, 1.15rc1 is valid
-var goVerRegex = regexp.MustCompile(`^([0-9]+)\.([0-9]+)([\.1-9A-Za-z\-]*$)`)
+var goVerRegex = regexp.MustCompile(`^([0-9]+)\.([0-9]\w*)(\.[1-9]\d*\w*)*$`)
 
 func ensureValidGoVersion(version string) error {
 	if !goVerRegex.MatchString(version) {

--- a/cmd/publishing-bot/config/rules_test.go
+++ b/cmd/publishing-bot/config/rules_test.go
@@ -23,7 +23,12 @@ func TestValidateGoVersion(t *testing.T) {
 		ver     string
 		isValid bool
 	}{
+		{"0.0", true},
+		{"0.0rc1", true},
+		{"0.9", true},
+		{"0.9.0", false},
 		{"1.9", true},
+		{"0.0.1", true},
 		{"1.9.0", false},
 		{"1.9.1", true},
 		{"1.15", true},
@@ -33,6 +38,16 @@ func TestValidateGoVersion(t *testing.T) {
 		{"1.15.0-beta.1", false},
 		{"1.15rc1", true},
 		{"1.15.0-rc.1", false},
+		{"1.15.10", true},
+		{"1.15.11", true},
+		{"1.15.20", true},
+		{"2.0", true},
+		{"2.0alpha1", true},
+		{"2.0-alpha1", false},
+		{"12.12.100", true},
+		{"999.999.9999", true},
+		{"999.999.9999-beta.1", false},
+		{"999.999.9999beta1", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In the PR to bump the go version to 1.15.10 in the kubernetes/kubernetes repo, the publishingbot failed to validate the go version `1.15.10`, see prwo job: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/100375/pull-publishing-bot-validate/1372599248561901568

```
I0318 17:24:03.759743     155 rules.go:94] loading rules file : /home/prow/go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
I0318 17:24:03.778078     155 rules.go:130] validating repository order
I0318 17:24:03.778167     155 rules.go:152] validating go versions
F0318 17:24:03.778287     155 main.go:35] Invalid rules file "/home/prow/go/src/k8s.io/kubernetes/staging/publishing/rules.yaml": validation errors:
- specified go version 1.15.10 is invalid
```

however this version is a valid one, This PR update the regex that validates the go version and add some extra test cases

/assign @nikhita @justaugustus 

/kind bug
/priority critical-urgent