### PR TITLE
go.mod: Update module to go1.17 and fix lithammer/dedent import

### DIFF
--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/golang/glog"
-	"github.com/renstrom/dedent"
+	"github.com/lithammer/dedent"
 	gogit "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,39 @@
 module k8s.io/publishing-bot
 
-go 1.13
+go 1.17
 
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54 // indirect
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
 	github.com/renstrom/dedent v1.0.0
 	github.com/shurcooL/go v0.0.0-20171108033853-004faa6b0118
 	golang.org/x/mod v0.4.3-0.20210409134425-858fdbee9c24
 	golang.org/x/oauth2 v0.0.0-20171205225816-ea8c6730ed5b
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	google.golang.org/appengine v1.0.1-0.20171031194329-9d8544a6b2c7 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
-	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.9.1
 	gopkg.in/yaml.v2 v2.0.0-20150924142314-53feefa2559f
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54 // indirect
+	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e // indirect
+	github.com/mitchellh/go-homedir v1.0.0 // indirect
+	github.com/pelletier/go-buffruneio v0.2.0 // indirect
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/xanzy/ssh-agent v0.2.0 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
+	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	google.golang.org/appengine v1.0.1-0.20171031194329-9d8544a6b2c7 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/renstrom/dedent v1.0.0
+	github.com/lithammer/dedent v1.0.0
 	github.com/shurcooL/go v0.0.0-20171108033853-004faa6b0118
 	golang.org/x/mod v0.4.3-0.20210409134425-858fdbee9c24
 	golang.org/x/oauth2 v0.0.0-20171205225816-ea8c6730ed5b

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.1.1 h1:j3L6gSLQalDETeEg/Jg0mGY0/y/N6zI2xX1978P0Uqw=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lithammer/dedent v1.0.0 h1:rLF1uRgU2783qnoHLRBymNcPIj/3LMr+9eZNaNI6law=
+github.com/lithammer/dedent v1.0.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
@@ -42,8 +44,6 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/renstrom/dedent v1.0.0 h1:MKUQ4Nr+V8f9ax+9wYAx5GhspvFzs47vK0oXePaVoWk=
-github.com/renstrom/dedent v1.0.0/go.mod h1:M3t8jnE/HlAaLf3m0P158lCmrc8ZErlRB4/cN6V5TXY=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/go v0.0.0-20171108033853-004faa6b0118 h1:ygJUdybU9Z/Z7vMcMUL3wyXpYKlXvh8rGElC04RpJqw=


### PR DESCRIPTION
- go.mod: Update module to go1.17
- go.mod: renstrom/dedent is now lithammer/dedent

Fixes: https://github.com/kubernetes/publishing-bot/issues/248

/assign @nikhita @liggitt 