### PR TITLE
Allow specifying branch-specific smoke tests

### DIFF
--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -53,14 +53,17 @@ type BranchRule struct {
 	Dependencies     []Dependency `yaml:"dependencies,omitempty"`
 	Source           Source       `yaml:"source"`
 	RequiredPackages []string     `yaml:"required-packages,omitempty"`
+	// SmokeTest applies only to the specific branch
+	SmokeTest string `yaml:"smoke-test,omitempty"` // a multiline bash script
 }
 
 // a collection of publishing rules for a single destination repo
 type RepositoryRule struct {
 	DestinationRepository string       `yaml:"destination"`
 	Branches              []BranchRule `yaml:"branches"`
-	SmokeTest             string       `yaml:"smoke-test,omitempty"` // a multiline bash script
-	Library               bool         `yaml:"library,omitempty"`
+	// SmokeTest applies to all branches
+	SmokeTest string `yaml:"smoke-test,omitempty"` // a multiline bash script
+	Library   bool   `yaml:"library,omitempty"`
 	// not updated when true
 	Skip bool `yaml:"skipped,omitempty"`
 }


### PR DESCRIPTION
Currently, smoke tests are specified for the entire repo and apply to
all branches. However, this leads to problems when a single test cannot
be run across all branches.

For example, the smoke test for client-go uses `go test -mod=mod ./...`.
The `-mod=mod` option is available only from go1.14 and is necessary for
running tests with go1.16 (https://github.com/kubernetes/kubernetes/pull/99674)

client-go `release-1.18` branch uses go1.13.15 which doesn't support the
`-mod=mod` option, so the tests fail.

This commit fixes this issue by additionally allowing to specify smoke
tests per branch. The current option for tests that apply to all
branches is not changed to maintain compatibility.

Note: this issue got triggered because there was a recent change to the
client-go `release-1.18` branch in https://github.com/kubernetes/kubernetes/pull/100376

PR for updating rules in k/k - https://github.com/kubernetes/kubernetes/pull/100554

/assign @sttts 