### PR TITLE
Add update-rules command to update publishing-bot rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ ADD _output/publishing-bot /publishing-bot
 ADD _output/collapsed-kube-commit-mapper /collapsed-kube-commit-mapper
 ADD _output/sync-tags /sync-tags
 ADD _output/init-repo /init-repo
+ADD _output/update-rules /update-rules
 
 ADD _output/gomod-zip /gomod-zip
 ADD artifacts/scripts/ /publish_scripts

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ build:
 	$(call build_cmd,sync-tags)
 	$(call build_cmd,init-repo)
 	$(call build_cmd,gomod-zip)
+	$(call build_cmd,update-rules)
 .PHONY: build
 
 build-image: build

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ This will not push to your org, but runs in dry-run mode. To run with a push, ad
 
 **Note:**: Details about running the publishing-bot for the Kubernetes project can be found in [k8s-publishing-bot.md](k8s-publishing-bot.md).
 
+
+### Update rules
+
+To add new branch rules or update go version for configured destination repos, check [update-branch-rules](cmd/update-rules/README.md).
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute.

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -31,7 +31,7 @@ func (c Dependency) String() string {
 
 // Source of a piece of code
 type Source struct {
-	Repository string `yaml:"repository"`
+	Repository string `yaml:"repository,omitempty"`
 	Branch     string `yaml:"branch"`
 	// Dir from repo root
 	Dir string `yaml:"dir,omitempty"`
@@ -48,7 +48,7 @@ func (c Source) String() string {
 type BranchRule struct {
 	Name string `yaml:"name"`
 	// a valid go version string like 1.10.2 or 1.10
-	GoVersion string `yaml:"go"`
+	GoVersion string `yaml:"go,omitempty"`
 	// k8s.io/* repos the branch rule depends on
 	Dependencies     []Dependency `yaml:"dependencies,omitempty"`
 	Source           Source       `yaml:"source"`
@@ -69,9 +69,9 @@ type RepositoryRule struct {
 }
 
 type RepositoryRules struct {
-	SkippedSourceBranches []string         `yaml:"skip-source-branches"`
-	SkipGomod             bool             `yaml:"skip-gomod"`
-	SkipTags              bool             `yaml:"skip-tags"`
+	SkippedSourceBranches []string         `yaml:"skip-source-branches,omitempty"`
+	SkipGomod             bool             `yaml:"skip-gomod,omitempty"`
+	SkipTags              bool             `yaml:"skip-tags,omitempty"`
 	Rules                 []RepositoryRule `yaml:"rules"`
 
 	// ls-files patterns like: */BUILD *.ext pkg/foo.go Makefile

--- a/cmd/update-rules/README.md
+++ b/cmd/update-rules/README.md
@@ -12,23 +12,55 @@ branch rule to configured branches.
 
 For existing branch rule, it updates the given go version for each destination repository.
 
+### Build:
+
+To build the `update-rules` CLI binary, run:
+
+##### Linux:
+
+```
+make build
+```
+
+##### macOS:
+
+```
+GOOS=darwin make build
+```
+
+The generated binary will be located at `_output/update-rules`.
+
+##### Container Image:
+
+To build the container image, run:
+
+```
+make build-image
+```
+
+`update-rules` binary will be available at the root `/` in the image and can be invoked as:
+
+```
+docker run -t gcr.io/k8s-staging-publishing-bot/publishing-bot:latest /update-rules
+```
+
 ### Usage:
 
 Run the command line as:
 ```
-  go run cmd/update-rules/main.go -h
+  update-rules -h
 
-  Usage:  update-rules --branch BRANCH --rules PATHorURL [--go VERSION | -o PATH]
+  Usage: update-rules --branch BRANCH --rules PATHorURL [--go VERSION | -o PATH]
 
   Examples:
-  # Update rules for branch release-1.21 with go version 1.16.4
-  update-rules -branch release-1.21 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+  # Update rules for branch release-1.23 with go version 1.16.4
+  update-rules -branch release-1.23 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
 
   # Update rules using URL to input rules file
-  update-rules -branch release-1.21 -go 1.16.4 -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
+  update-rules -branch release-1.23 -go 1.16.4 -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
 
   # Update rules and export to /tmp/rules.yaml
-  update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+  update-rules -branch release-1.24 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
 
   -alsologtostderr
     	log to standard error as well as files

--- a/cmd/update-rules/README.md
+++ b/cmd/update-rules/README.md
@@ -18,10 +18,10 @@ Run the command line as:
 ```
   go run cmd/update-rules/main.go -h
 
-  Usage:  update-rules --branch BRANCH --rules PATH [--go VERSION | -o PATH]
+  Usage:  update-rules --branch BRANCH --rules PATHorURL [--go VERSION | -o PATH]
 
   Examples:
-  # Update rules for branch release-1.21 with go version 1.16.1
+  # Update rules for branch release-1.21 with go version 1.16.4
   update-rules -branch release-1.21 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
 
   # Update rules using URL to input rules file

--- a/cmd/update-rules/README.md
+++ b/cmd/update-rules/README.md
@@ -1,0 +1,65 @@
+Update branch rules
+===================
+
+Command line tooling to manage following operations for branch rules of existing destination repo:
+ - add a new branch rule
+    - with go version
+    - without go version (sets blank "" go version)
+ - update an existing branch rule with given go version
+
+For new branch rule, it refers the 'master' branch rule for each destination repository and appends the new
+branch rule to configured branches.
+
+For existing branch rule, it updates the given go version for each destination repository.
+
+### Usage:
+
+Run the command line as:
+```
+  go run cmd/update-rules/main.go -h
+
+  Usage:  update-rules --branch BRANCH --rules PATH [--go VERSION | -o PATH]
+
+  Examples:
+  # Update rules for branch release-1.21 with go version 1.16.1
+  update-rules -branch release-1.21 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+
+  # Update rules using URL to input rules file
+  update-rules -branch release-1.21 -go 1.16.4 -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
+
+  # Update rules and export to /tmp/rules.yaml
+  update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+
+  -alsologtostderr
+    	log to standard error as well as files
+  -branch string
+    	[required] Branch to update rules for, e.g. --branch release-x.yy
+  -go string
+    	Golang version to pin for this branch, e.g. --go 1.16.1
+  -log_backtrace_at value
+    	when logging hits line file:N, emit a stack trace
+  -log_dir string
+    	If non-empty, write log files in this directory
+  -logtostderr
+    	log to standard error instead of files
+  -o string
+    	Path to export the updated rules to, e.g. -o /tmp/rules.yaml
+  -rules string
+    	[required] URL or Path of the rules file to update rules for, e.g. --rules path/or/url/to/rules/file.yaml
+  -stderrthreshold value
+    	logs at or above this threshold go to stderr
+  -v value
+    	log level for V logs
+  -vmodule value
+    	comma-separated list of pattern=N settings for file-filtered logging
+```
+
+#### Required flags:
+
+- `-rules` flag with value is required for processing input rules file
+- `-branch` flag with value is required for adding/updating rules for all destination repos
+
+#### Optional flags:
+
+- `-go` flag refers to golang version which should be pinned for given branch, if not given an empty string is set
+- `-o` flag refers to output file where the processed rules should be exported, otherwise rules are printed on stdout

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -54,7 +54,7 @@ func parseOptions() options {
   update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml`
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stdout, "\n  Usage:  update-rules --branch BRANCH --rules PATH [--go VERSION | -o PATH]")
+		fmt.Fprintf(os.Stdout, "\n  Usage:  update-rules --branch BRANCH --rules PATHorURL [--go VERSION | -o PATH]")
 		fmt.Fprintf(os.Stdout, "\n  %s\n\n", examples)
 		flag.PrintDefaults()
 	}

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"gopkg.in/yaml.v2"
+	"k8s.io/publishing-bot/cmd/publishing-bot/config"
+)
+
+type options struct {
+	branch    string
+	rulesFile string
+	goVersion string
+	out       string
+}
+
+func parseOptions() options {
+	var o options
+	flag.StringVar(&o.branch, "branch", "", "[required] Branch to update rules for, e.g. --branch release-x.yy")
+	flag.StringVar(&o.rulesFile, "rules", "", "[required] URL or Path of the rules file to update rules for, e.g. --rules path/or/url/to/rules/file.yaml")
+	flag.StringVar(&o.goVersion, "go", "", "Golang version to pin for this branch, e.g. --go 1.16.1")
+	flag.StringVar(&o.out, "o", "", "Path to export the updated rules to, e.g. -o /tmp/rules.yaml")
+
+	examples := `
+  Examples:
+  # Update rules for branch release-1.21 with go version 1.16.1
+  update-rules -branch release-1.21 -go 1.16.1 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+
+  # Update rules and export to /tmp/rules.yaml for branch release-1.22 with go version version 1.17.1
+  update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml`
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stdout, "\n  Usage:  update-rules --branch BRANCH --rules PATH [--go VERSION | -o PATH]")
+		fmt.Fprintf(os.Stdout, "\n  %s\n\n", examples)
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if o.branch == "" {
+		glog.Errorf("branch flag requires a non-empty value, e.g. --branch release-x.yy")
+		os.Exit(2)
+	}
+
+	if o.rulesFile == "" {
+		glog.Errorf("rules flag requires a non-empty value, e.g. --rules path/or/url/to/rules/file.yaml")
+		os.Exit(2)
+	}
+
+	return o
+}
+
+func main() {
+	o := parseOptions()
+
+	// load and validate input rules file
+	rules, err := load(o.rulesFile)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// update rules for all destination repos
+	UpdateRules(rules, o.branch, o.goVersion)
+
+	// validate rules after update
+	if err := config.Validate(rules); err != nil {
+		glog.Fatalf("update failed, found invalid rules after update: %v", err)
+	}
+
+	data, err := yaml.Marshal(rules)
+	if err != nil {
+		glog.Fatalf("error marshaling rules %v", err)
+	}
+
+	if o.out != "" {
+		err = exportRules(o.out, data)
+		if err != nil {
+			glog.Fatalf("error exporting the rules %v", err)
+		}
+	} else {
+		fmt.Fprintf(os.Stdout, string(data))
+	}
+}
+
+// load reads the input rules file and validates the rules
+func load(rulesFile string) (*config.RepositoryRules, error) {
+	rules, err := config.LoadRules(rulesFile)
+	if err != nil {
+		return nil, fmt.Errorf("error loading rules file %q: %v", rulesFile, err)
+	}
+
+	if err := config.Validate(rules); err != nil {
+		return nil, fmt.Errorf("invalid rules file %q: %v", rulesFile, err)
+	}
+	return rules, nil
+}
+
+func UpdateRules(rules *config.RepositoryRules, branch, goVer string) {
+	// run the update per destination repo in the rules
+	for j, r := range rules.Rules {
+		var mainBranchRuleFound bool
+		var newBranchRule config.BranchRule
+		// find the mainBranch rules
+		for _, br := range r.Branches {
+			if br.Name == "master" {
+				cloneBranchRule(&br, &newBranchRule)
+				mainBranchRuleFound = true
+				break
+			}
+		}
+
+		// if mainBranch rules not found for repo, it means it's removed from master tree, log warning and skip updating the rules
+		if !mainBranchRuleFound {
+			glog.Warningf("master branch rules not found for repo %s, skipping to update branch %s rules", r.DestinationRepository, branch)
+			continue
+		}
+
+		// update the rules for branch and its dependencies
+		updateBranchRules(&newBranchRule, branch, goVer)
+
+		var branchRuleExists bool
+		// if the target branch rules already exists, update it
+		for i, br := range r.Branches {
+			if br.Name == branch {
+				glog.Infof("found branch %s rules for destination repo %s, updating it", branch, r.DestinationRepository)
+				r.Branches[i] = newBranchRule
+				branchRuleExists = true
+				break
+			}
+		}
+		// new rules, append to destination's branches
+		if !branchRuleExists {
+			r.Branches = append(r.Branches, newBranchRule)
+		}
+
+		// update the rules for destination repo
+		rules.Rules[j] = r
+	}
+}
+
+func cloneBranchRule(in, out *config.BranchRule) {
+	if in == nil {
+		return
+	}
+	*out = *in
+	if in.Dependencies != nil {
+		out.Dependencies = make([]config.Dependency, len(in.Dependencies))
+		for i := range in.Dependencies {
+			out.Dependencies[i] = in.Dependencies[i]
+		}
+	}
+}
+
+func updateBranchRules(br *config.BranchRule, branch, goVersion string) {
+	br.Name = branch
+	br.Source.Branch = branch
+	br.GoVersion = goVersion
+	for k, _ := range br.Dependencies {
+		br.Dependencies[k].Branch = branch
+	}
+}
+
+func exportRules(fPath string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(fPath), 0755); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(fPath, data, 0644)
+}

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -62,7 +62,7 @@ func parseOptions() options {
 	flag.Parse()
 
 	if o.branch == "" {
-		glog.Errorf("branch flag requires a non-empty value, e.g. --branch release-x.yy")
+		glog.Errorf("branch flag requires a non-empty value, e.g. --branch release-x.yy. Run `update-rules -h` for help!")
 		os.Exit(2)
 	}
 

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -45,9 +45,12 @@ func parseOptions() options {
 	examples := `
   Examples:
   # Update rules for branch release-1.21 with go version 1.16.1
-  update-rules -branch release-1.21 -go 1.16.1 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
+  update-rules -branch release-1.21 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
 
-  # Update rules and export to /tmp/rules.yaml for branch release-1.22 with go version version 1.17.1
+  # Update rules using URL to input rules file
+  update-rules -branch release-1.21 -go 1.16.4 -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
+
+  # Update rules and export to /tmp/rules.yaml
   update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml`
 
 	flag.Usage = func() {

--- a/cmd/update-rules/main_test.go
+++ b/cmd/update-rules/main_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+var (
+	testdataRules        = "testdata/rules.yaml"
+	testdataInvalidRules = "testdata/invalid_rules.yaml"
+	remoteRules          = "https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml"
+)
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		{
+			"local testdata valid rules file",
+			testdataRules,
+			false,
+		},
+		{
+			"local testdata invalid rules file with invalid go version",
+			testdataInvalidRules,
+			true,
+		},
+		{
+			"remote valid rules file",
+			remoteRules,
+			false,
+		},
+		{
+			"local invalid path to rules file",
+			"/invalid/path.yaml",
+			true,
+		},
+		{
+			"remote 404 rules files",
+			"https://foo.bar/rules.yaml",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := load(tt.input)
+			if err != nil && !tt.expectErr {
+				t.Errorf("error loading test rules file from %s , did not expect error", tt.input)
+			}
+			if err == nil && tt.expectErr {
+				t.Errorf("expected error while loading rules from %s , but got none", tt.input)
+			}
+		})
+	}
+}
+
+func TestUpdateRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		branch    string
+		goVersion string
+	}{
+		{
+			"new branch with go version",
+			"release-1.XY",
+			"1.17.1",
+		},
+		{
+			"new branch with go version",
+			"release-1.XY",
+			"1.17.1",
+		},
+		{
+			"new branch without go version",
+			"release-1.XY",
+			"",
+		},
+		{
+			"existing branch rule with go version update",
+			"release-1.21",
+			"1.16.1",
+		},
+		{
+			"master branch rule update for go version",
+			"master",
+			"1.16.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules, err := load(testdataRules)
+			if err != nil {
+				t.Errorf("error loading test rules file %v", err)
+			}
+			UpdateRules(rules, tt.branch, tt.goVersion)
+
+			for _, repoRule := range rules.Rules {
+				var masterRulePresent, branchRulePresent bool
+				var masterRuleIndex, branchRuleIndex int
+
+				for i, branchRule := range repoRule.Branches {
+					switch branchRule.Name {
+					case "master":
+						masterRulePresent = true
+						masterRuleIndex = i
+					case tt.branch:
+						branchRulePresent = true
+						branchRuleIndex = i
+					}
+				}
+				switch masterRulePresent {
+				case true:
+					if !branchRulePresent && tt.branch != "master" {
+						t.Errorf("error updating branch %s rule for repo %s", tt.branch, repoRule.DestinationRepository)
+					}
+				case false:
+					if branchRulePresent {
+						t.Errorf("incorrectly added branch %s rule for repo %s whose master branch rule does not exists", tt.branch, repoRule.DestinationRepository)
+					}
+				}
+
+				if repoRule.Branches[branchRuleIndex].Source.Branch != tt.branch {
+					t.Errorf("incorrect update to branch %s rule for source branch field for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+
+				if repoRule.Branches[masterRuleIndex].Source.Dir != repoRule.Branches[branchRuleIndex].Source.Dir {
+					t.Errorf("incorrect update to branch %s rule for source dir field for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+
+				if repoRule.Branches[branchRuleIndex].GoVersion != tt.goVersion {
+					t.Errorf("incorrect go version set for branch %s rule for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+
+				if len(repoRule.Branches[masterRuleIndex].Dependencies) != len(repoRule.Branches[branchRuleIndex].Dependencies) {
+					t.Errorf("incorrect update to branch %s rule dependencies for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+
+				if len(repoRule.Branches[masterRuleIndex].RequiredPackages) != len(repoRule.Branches[branchRuleIndex].RequiredPackages) {
+					t.Errorf("incorrect update to branch %s rule required packages for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+
+				if repoRule.Branches[masterRuleIndex].SmokeTest != repoRule.Branches[branchRuleIndex].SmokeTest {
+					t.Errorf("incorrect update to branch %s rule smoke-test for repo %s", tt.branch, repoRule.DestinationRepository)
+				}
+			}
+		})
+	}
+}

--- a/cmd/update-rules/testdata/invalid_rules.yaml
+++ b/cmd/update-rules/testdata/invalid_rules.yaml
@@ -1,0 +1,12 @@
+rules:
+- destination: code-generator
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/code-generator
+    name: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.19
+    go: 1.15.0    # invalid go version

--- a/cmd/update-rules/testdata/rules.yaml
+++ b/cmd/update-rules/testdata/rules.yaml
@@ -1,0 +1,1471 @@
+recursive-delete-patterns:
+# TODO: remove bazel related files after we stop publishing branches with
+# bazel files
+# See: https://github.com/kubernetes/enhancements/issues/2420
+- BUILD
+- "*/BUILD"
+- BUILD.bazel
+- "*/BUILD.bazel"
+- Gopkg.toml
+default-go-version: 1.16.4
+rules:
+- destination: code-generator
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/code-generator
+    name: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.19
+    go: 1.15.12
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.20
+    go: 1.15.12
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.21
+
+- destination: apimachinery
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apimachinery
+    name: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.19
+    go: 1.15.12
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.20
+    go: 1.15.12
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.21
+
+- destination: api
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/api
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/api
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/api
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/api
+    name: release-1.21
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.21
+
+- destination: client-go
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/client-go
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/client-go
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.19
+      - repository: api
+        branch: release-1.19
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/client-go
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.20
+      - repository: api
+        branch: release-1.20
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/client-go
+    name: release-1.21
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.21
+      - repository: api
+        branch: release-1.21
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
+
+- destination: component-base
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/component-base
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/component-base
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/component-base
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/component-base
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: component-helpers
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/component-helpers
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/component-helpers
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/component-helpers
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: apiserver
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+
+- destination: kube-aggregator
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-aggregator
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: code-generator
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+
+- destination: sample-apiserver
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+
+- destination: sample-controller
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-controller
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: code-generator
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+
+- destination: apiextensions-apiserver
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    required-packages:
+    - k8s.io/code-generator
+
+- destination: metrics
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/metrics
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: code-generator
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/metrics
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/metrics
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/metrics
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+
+- destination: cli-runtime
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cli-runtime
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: sample-cli-plugin
+  library: false
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: cli-runtime
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: cli-runtime
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: cli-runtime
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: cli-runtime
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: kube-proxy
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-proxy
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: kubelet
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kubelet
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+
+- destination: kube-scheduler
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-scheduler
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+
+- destination: controller-manager
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/controller-manager
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: apiserver
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.19
+    go: 1.15.12
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/controller-manager
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+
+- destination: cloud-provider
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cloud-provider
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: controller-manager
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: controller-manager
+      branch: release-1.21
+
+- destination: kube-controller-manager
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: api
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: controller-manager
+      branch: master
+    - repository: cloud-provider
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
+    - repository: cloud-provider
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: controller-manager
+      branch: release-1.21
+    - repository: cloud-provider
+      branch: release-1.21
+
+- destination: cluster-bootstrap
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: master
+    dependencies:
+    - repository: apimachinery
+      branch: master
+    - repository: api
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: api
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: api
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.21
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: api
+      branch: release-1.21
+
+- destination: csi-translation-lib
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: cloud-provider
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+
+- destination: mount-utils
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/mount-utils
+    name: master
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/mount-utils
+    name: release-1.20
+    go: 1.15.12
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/mount-utils
+    name: release-1.21
+
+- destination: legacy-cloud-providers
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: cloud-provider
+      branch: master
+    - repository: csi-translation-lib
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: controller-manager
+      branch: master
+    - repository: mount-utils
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: cloud-provider
+      branch: release-1.19
+    - repository: csi-translation-lib
+      branch: release-1.19
+    - repository: apiserver
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: cloud-provider
+      branch: release-1.20
+    - repository: csi-translation-lib
+      branch: release-1.20
+    - repository: apiserver
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: controller-manager
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: cloud-provider
+      branch: release-1.21
+    - repository: csi-translation-lib
+      branch: release-1.21
+    - repository: apiserver
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: controller-manager
+      branch: release-1.21
+
+- destination: cri-api
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/cri-api
+    name: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.19
+    go: 1.15.12
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.20
+    go: 1.15.12
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.21
+
+- destination: kubectl
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/kubectl
+    name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: cli-runtime
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: code-generator
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: component-helpers
+      branch: master
+    - repository: metrics
+      branch: master
+  - source:
+      branch: release-1.19
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.19
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.19
+    - repository: apimachinery
+      branch: release-1.19
+    - repository: cli-runtime
+      branch: release-1.19
+    - repository: client-go
+      branch: release-1.19
+    - repository: code-generator
+      branch: release-1.19
+    - repository: component-base
+      branch: release-1.19
+    - repository: metrics
+      branch: release-1.19
+  - source:
+      branch: release-1.20
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.20
+    go: 1.15.12
+    dependencies:
+    - repository: api
+      branch: release-1.20
+    - repository: apimachinery
+      branch: release-1.20
+    - repository: cli-runtime
+      branch: release-1.20
+    - repository: client-go
+      branch: release-1.20
+    - repository: code-generator
+      branch: release-1.20
+    - repository: component-base
+      branch: release-1.20
+    - repository: component-helpers
+      branch: release-1.20
+    - repository: metrics
+      branch: release-1.20
+  - source:
+      branch: release-1.21
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.21
+    dependencies:
+    - repository: api
+      branch: release-1.21
+    - repository: apimachinery
+      branch: release-1.21
+    - repository: cli-runtime
+      branch: release-1.21
+    - repository: client-go
+      branch: release-1.21
+    - repository: code-generator
+      branch: release-1.21
+    - repository: component-base
+      branch: release-1.21
+    - repository: component-helpers
+      branch: release-1.21
+    - repository: metrics
+      branch: release-1.21
+
+- destination: pod-security-admission
+  library: true
+  branches:
+  - source:
+      branch: master
+      dir: staging/src/k8s.io/pod-security-admission
+    name: master


### PR DESCRIPTION
### Description:
 - Add `cmd/update-rules` to update publishing-bot rules
 - Required flags: `--rules`, `--branch`
 - Exports the updated rules to file pointed by `-o` otherwise on prints stdout
 - Pin go version provided by `--go` flag else leave the field empty (`omitempty`)
 - Refer master branch rule per destination repo to add/update rule for provided branch

### Usage:
```
Usage:  update-rules --branch BRANCH --rules PATH [--go VERSION | -o PATH]
```
 
### Examples:
  - Update rules for branch release-1.21 with go version 1.16.4
  ```
    update-rules -branch release-1.21 -go 1.16.4 -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
   ```
  - Update rules using URL to input rules file
  ```
  update-rules -branch release-1.21 -go 1.16.4 -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
  ```

  - Update rules and export to /tmp/rules.yaml
```
  update-rules -branch release-1.22 -go 1.17.1 -o /tmp/rules.yaml -rules /go/src/k8s.io/kubernetes/staging/publishing/rules.yaml
```

fixes #252 

TODO:
- [x] command
- [x] tests
- [x] docs