### PR TITLE
Fix more checksum errors

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -875,7 +875,7 @@ update-deps-in-gomod() {
     rm go.sum
 
     GO111MODULE=on GOPRIVATE="${dep_packages}" GOPROXY=https://proxy.golang.org go mod download
-    GOPROXY="file://${GOPATH}/pkg/mod/cache/download" GO111MODULE=on go mod tidy
+    GOPROXY="file://${GOPATH}/pkg/mod/cache/download" GO111MODULE=on GOPRIVATE="${dep_packages}" go mod tidy
 
     git add go.mod go.sum
 

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -943,10 +943,6 @@ checkout-deps-to-kube-commit() {
             echo "Checking out k8s.io/${dep} to ${dep_commit}"
             git checkout -q "${dep_commit}"
 
-            echo "Downloading go mod dependencies..."
-            GO111MODULE=on GOPRIVATE="${dep_packages}" GOPROXY=https://proxy.golang.org go mod download
-            git checkout HEAD go.sum # avoid side-effects. go mod download might pull in news tags for old SHAs
-
             local pseudo_version=$(gomod-pseudo-version)
             local cache_dir="${GOPATH}/pkg/mod/cache/download/${base_package}/${dep}/@v"
             if [ -f "${cache_dir}/list" ] && grep -q "${pseudo_version}" "${cache_dir}/list"; then


### PR DESCRIPTION
This PR contains two fixes/commits. The commit messages have more details.

- Use `GOPRIVATE` before `go mod tidy` to avoid errors like:

```
+ go mod tidy
k8s.io/apimachinery@v0.0.0-20210421190751-2d51b868ae8a: verifying module: k8s.io/apimachinery@v0.0.0-20210421190751-2d51b868ae8a: reading https://sum.golang.org/lookup/k8s.io/apimachinery@v0.0.0-20210421190751-2d51b868ae8a: 410 Gone
    server response: not found: k8s.io/apimachinery@v0.0.0-20210421190751-2d51b868ae8a: invalid version: unknown revision 2d51b868ae8a
```

- Remove obsolete `go mod download` before packaging up dependencies into go mod cache. This causes an error if a published go.mod contains an incorrect hash. Removing these lines unblocks publishing a fixed go.mod file.

```
verifying k8s.io/client-go@v0.0.0-20210401152202-307e3a38a167: checksum mismatch
    downloaded: h1:opqPJ8l/hqiKIseiNVxcUiYF0vc8gAcyy/rZZrxseTs=
    go.sum:     h1:6dfdaZ0/RfxMbyUuuKL4xdk4+DVjkO76nmb6z4S+bn0=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```


/assign @sttts @dims 
