### PR TITLE
Correctly set GOPRIVATE and remove go.sum only if non-empty

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -872,7 +872,7 @@ update-deps-in-gomod() {
     #
     # So remove go.sum here and regenerate again using
     # go mod download and go mod tidy.
-    rm go.sum
+    [ -s go.sum ] && rm go.sum
 
     GO111MODULE=on GOPRIVATE="${dep_packages}" GOPROXY=https://proxy.golang.org go mod download
     GOPROXY="file://${GOPATH}/pkg/mod/cache/download" GO111MODULE=on GOPRIVATE="${dep_packages}" go mod tidy

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -117,7 +117,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string, semverTag 
 	}
 
 	tidyCommand := exec.Command("go", "mod", "tidy")
-	tidyCommand.Env = append(os.Environ(), "GO111MODULE=on", fmt.Sprintf("GOPROXY=file://%s/pkg/mod/cache/download", os.Getenv("GOPATH")))
+	tidyCommand.Env = append(os.Environ(), "GO111MODULE=on", fmt.Sprintf("GOPROXY=file://%s/pkg/mod/cache/download", os.Getenv("GOPATH")), fmt.Sprintf("GOPRIVATE=%s", depPackages))
 	tidyCommand.Stdout = os.Stdout
 	tidyCommand.Stderr = os.Stderr
 	if err := tidyCommand.Run(); err != nil {

--- a/hack/fetch-all-latest-and-push.sh
+++ b/hack/fetch-all-latest-and-push.sh
@@ -55,6 +55,7 @@ repos=(
     kube-scheduler
     legacy-cloud-providers
     metrics
+    mount-utils
     node-api
     sample-apiserver
     sample-cli-plugin


### PR DESCRIPTION
This PR contains two fixes, the commit messages contain more details.

- The first commit removes go.sum only if it is non-empty. If we remove go.sum if it is empty, it will not be recreated in the next step while running `go mod tidy` and will lead to errors like:
<details><summary>Expand to display error</summary>

```
   	+ rm go.sum
    	+ GO111MODULE=on
    	+ GOPRIVATE=
    	+ GOPROXY=https://proxy.golang.org
    	+ go mod download
    	+ GOPROXY=file:///go-workspace/pkg/mod/cache/download
    	+ GO111MODULE=on
    	+ GOPRIVATE=
    	+ go mod tidy
    	+ git add go.mod go.sum
    	+ grep 000000000000 go.sum
    	grep: go.sum: No such file or directory
    	+ git-index-clean
    	+ git diff --cached --exit-code
    	+ return 1
    	+ echo 'Committing go.mod'
    	+ git commit -q -m 'sync: update go.mod'
    	+ ensure-clean-working-dir
    	+ git diff HEAD --exit-code
    	+ '[' true == true ']'
    	+ mkdir -p Godeps
    	+ echo 'Resolving dependencies for Godeps.json generation'
    	+ GOPROXY=file:///go-workspace/pkg/mod/cache/download
    	+ GO111MODULE=on
    	+ go list -m -json all
    	+ /godeps-gen /tmp/go-list Godeps/Godeps.json
    	+ git add Godeps go.mod go.sum
    	fatal: pathspec 'go.sum' did not match any files
```
</details>

- The second commits makes the same changes as https://github.com/kubernetes/publishing-bot/commit/8cf9487aefc6e45485a21bea81de3a5044a38de8 but for sync-tags.
- The third commit adds the `mount-utils` repo to the `hack/fetch-all-latest-and-push.sh` script used for testing.

/hold
/assign @dims 