### PR TITLE
sync-tags: remove obsolete go mod download

### DIFF
--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -65,16 +65,6 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string, semverTag 
 			pseudoVersionOrTag = tag
 		}
 
-		// in case the pseudoVersion/tag has not changed, running go mod download will help
-		// in avoiding packaging it up if the pseudoVersion/tag has been published already
-		downloadCommand := exec.Command("go", "mod", "download")
-		downloadCommand.Env = append(os.Environ(), "GO111MODULE=on", fmt.Sprintf("GOPRIVATE=%s", depPackages), "GOPROXY=https://proxy.golang.org")
-		downloadCommand.Stdout = os.Stdout
-		downloadCommand.Stderr = os.Stderr
-		if err := downloadCommand.Run(); err != nil {
-			return changed, fmt.Errorf("error running go mod download for %s: %v", depPkg, err)
-		}
-
 		// check if we have the pseudoVersion/tag published already. if we don't, package it up
 		// and save to local mod download cache.
 		if err := packageDepToGoModCache(depPath, depPkg, rev, pseudoVersionOrTag, commitTime); err != nil {


### PR DESCRIPTION
Like https://github.com/kubernetes/publishing-bot/commit/ecc0e43fc19de91285c051ea3ae5fecca4a38ae8, but for syncing tags.

/hold
running nightly tests

/assign @dims 