### PR TITLE
Revert "Unconditionally remove Godeps"

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -509,13 +509,6 @@ sync_repo() {
         fix-gomod "${deps}" "${required_packages}" "${base_package}" "${is_library}" true false ${commit_msg_tag} "${recursive_delete_pattern}"
     fi
 
-    if [ -d Godeps ]; then
-        git rm -q -rf Godeps
-        if ! git-index-clean; then
-            git commit -q -m "sync: remove Godeps/"
-        fi
-    fi
-
     # create look-up file for collapsed upstream commits
     local repo=$(basename ${PWD})
     echo "Writing k8s.io/kubernetes commit lookup table to ../kube-commits-${repo}-${dst_branch}"


### PR DESCRIPTION
This reverts commit 070c1b6f9c02f340622a6e002b32bd2443951d0f.

This code removed the remaining `Godeps/Godeps.json` file from published repos. We have had a clean bot run and Godeps has now been [removed from the published repos](https://github.com/kubernetes/client-go/tree/master).

Given that k/k doesn't have Godeps anymore either, it is safe to remove this code from the publishing-bot.

/assign @dims 