### PR TITLE
OWNERS: Add Release Engineering reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,12 @@
 approvers:
+  #- sig-release-leads # TODO(owners): Enable upon the release of Kubernetes v1.24
+  #- release-engineering-approvers # TODO(owners): Enable upon the release of Kubernetes v1.24
   - dims
   - nikhita
   - sttts
 reviewers:
+  - release-engineering-approvers # TODO(owners): Remove upon the release of Kubernetes v1.24
+  #- release-engineering-reviewers # TODO(owners): Enable upon the release of Kubernetes v1.24
   - nikhita
 emeritus_approvers:
   - caesarxuchao

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ approvers:
   - nikhita
   - sttts
 reviewers:
-  - mfojtik
   - nikhita
 emeritus_approvers:
   - caesarxuchao

--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,5 @@ approvers:
 reviewers:
   - release-engineering-approvers # TODO(owners): Remove upon the release of Kubernetes v1.24
   #- release-engineering-reviewers # TODO(owners): Enable upon the release of Kubernetes v1.24
-  - nikhita
 emeritus_approvers:
   - caesarxuchao

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
+
+aliases:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,3 +1,25 @@
 # See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
 
 aliases:
+  sig-release-leads:
+    - cpanato # SIG Technical Lead
+    - jeremyrickard # SIG Technical Lead
+    - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
+    - saschagrunert # SIG Chair
+  release-engineering-approvers:
+    - cpanato # Release Manager
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - Verolop # Release Manager
+    - xmudrii # Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - mkorbi # Release Manager Associate
+    - palnabarun # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - sethmccombs # Release Manager Associate
+    - thejoycekung # Release Manager Associate
+    - wilsonehusin # Release Manager Associate

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,6 +10,11 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
+cpanato
+dims
+jeremyrickard
+justaugustus
+nikhita
+puerco
+saschagrunert
 sttts
-caesarxuchao
-mfojtik


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

- OWNERS: Generated update via dims/maintainers

  **NOTE**: I needed to create a placeholder OWNERS_ALIASES file for the
            tool to run successfully.

  ```console
  $(go env GOPATH)/bin/maintainers -f -r kubernetes/publishing-bot
  Running script : 12-03-2021 23:54:40
  Processing /Users/augustus/prj/k8s/publishing-bot/OWNERS_ALIASES
  Processing /Users/augustus/prj/k8s/publishing-bot/OWNERS
  Found 0 unique aliases
  Found 4 unique users

  >>>>> Contributions: 3
  >>>>> GitHub ID : Devstats contrib count : GitHub PR comment count
  nikhita : 58 : 15
  dims : 24 : 16
  sttts : 5 : 6

  >>>>> Missing Contributions (devstats == 0): 1
  "mfojtik"

  >>>>> Low reviews/approvals (GH pr comments <= 10 && devstats <=20): 1
  "sttts"
  Fixing up /Users/augustus/prj/k8s/publishing-bot/OWNERS
  Fixing up /Users/augustus/prj/k8s/publishing-bot/OWNERS_ALIASES
  ```

- OWNERS: Add Release Managers as reviewers

  This commit also adds the default aliases for Release Engineering
  repos. Our breakglass approver aliases are commented out to allow
  for a ramp-up period (to be uncommented upon the release of
  Kubernetes v1.24).

- OWNERS: Remove Nikhita as reviewer (best practice)

  Nikhita is already an approver for the repo.
  Given our guidance on maintaining OWNERS files:

  > the approvers are not in the reviewers section

  ref: https://go.k8s.io/owners#maintaining-owners-files

- SECURITY_CONTACTS: Update to reflect approvers + @kubernetes/sig-release-admins

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @nikhita @dims 
cc: @kubernetes/publishing-bot-reviewers @kubernetes/release-engineering 