### PR TITLE
Add GCB config for image building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ build-image: build
 push-image:
 	docker push $(DOCKER_REPO):latest
 
+build-and-push-image: build-image push-image
+.PHONY: build-and-push-image
+
 clean:
 	rm -rf _output
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ IMG_NAME = publishing-bot
 
 IMG_VERSION ?= v0.0.0-1
 
-BUILD_ARGS = --build-arg=GIT_TAG=$(GIT_TAG) \
-			 --build-arg=IMG_VERSION=$(IMG_VERSION)
-
 # TODO(image): Consider renaming this variable
 DOCKER_REPO ?= $(IMG_REGISTRY)/$(IMG_NAME)
 NAMESPACE ?=
@@ -60,7 +57,6 @@ build-image: build
 		-t $(DOCKER_REPO):$(GIT_TAG) \
 		-t $(DOCKER_REPO):$(IMG_VERSION) \
 		-t $(DOCKER_REPO):latest \
-		$(BUILD_ARGS) \
 		.
 .PHONY: build-image
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,10 +13,10 @@ steps:
 - name: 'gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default'
   entrypoint: make
   env:
-  - GIT_TAG=$_GIT_TAG
-  - PULL_BASE_REF=$_PULL_BASE_REF
-  - CLOUDBUILD_REPO=$PROJECT_ID
-  - IMG_VERSION=$_IMG_VERSION
+  - GIT_TAG="$_GIT_TAG"
+  - PULL_BASE_REF="$_PULL_BASE_REF"
+  - IMG_REGISTRY="gcr.io/$PROJECT_ID"
+  - IMG_VERSION="$_IMG_VERSION"
   args:
   - build-and-push-image
 
@@ -33,12 +33,14 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
+  _IMG_REGISTRY: 'registry'
   _IMG_VERSION: 'v0.0.0-1'
 
 tags:
 - 'publishing-bot'
 - ${_GIT_TAG}
 - ${_PULL_BASE_REF}
+- ${_IMG_REGISTRY}
 - ${_IMG_VERSION}
 
 images:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,47 @@
+# Google Cloud Build configuration: https://cloud.google.com/cloud-build/docs/build-config
+# Image building process: https://git.k8s.io/test-infra/config/jobs/image-pushing/README.md
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+
+options:
+  substitution_option: ALLOW_LOOSE
+  # TODO(image): Consider a smaller machine type
+  machineType: N1_HIGHCPU_32
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: make
+  env:
+  - GIT_TAG=$_GIT_TAG
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - CLOUDBUILD_REPO=$PROJECT_ID
+  - IMG_VERSION=$_IMG_VERSION
+  args:
+  - build-image
+
+# TODO(image): Consider adding a container structure test
+#- name: 'gcr.io/gcp-runtimes/container-structure-test'
+#  id: structure-test
+#  args:
+#  - test
+#  - --image=gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG
+#  - --config=container-structure.yaml
+
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'
+  _IMG_VERSION: 'v0.0.0-1'
+
+tags:
+- 'publishing-bot'
+- ${_GIT_TAG}
+- ${_PULL_BASE_REF}
+- ${_IMG_VERSION}
+
+images:
+- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
+- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
+- 'gcr.io/$PROJECT_ID/publishing-bot:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -42,8 +42,6 @@ tags:
 - ${_IMG_VERSION}
 
 images:
-# TODO(image): Enable once tagging logic exists
-#- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
-# TODO(image): Enable once tagging logic exists
-#- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
+- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
+- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
 - 'gcr.io/$PROJECT_ID/publishing-bot:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
   - CLOUDBUILD_REPO=$PROJECT_ID
   - IMG_VERSION=$_IMG_VERSION
   args:
-  - build-image
+  - build-and-push-image
 
 # TODO(image): Consider adding a container structure test
 #- name: 'gcr.io/gcp-runtimes/container-structure-test'
@@ -42,6 +42,8 @@ tags:
 - ${_IMG_VERSION}
 
 images:
-- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
-- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
+# TODO(image): Enable once tagging logic exists
+#- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
+# TODO(image): Enable once tagging logic exists
+#- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
 - 'gcr.io/$PROJECT_ID/publishing-bot:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,10 +13,10 @@ steps:
 - name: 'gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default'
   entrypoint: make
   env:
-  - GIT_TAG="$_GIT_TAG"
-  - PULL_BASE_REF="$_PULL_BASE_REF"
-  - IMG_REGISTRY="gcr.io/$PROJECT_ID"
-  - IMG_VERSION="$_IMG_VERSION"
+  - GIT_TAG=$_GIT_TAG
+  - PULL_BASE_REF=$_PULL_BASE_REF
+  - IMG_REGISTRY=gcr.io/$PROJECT_ID
+  - IMG_VERSION=$_IMG_VERSION
   args:
   - build-and-push-image
 
@@ -33,7 +33,7 @@ substitutions:
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'
-  _IMG_REGISTRY: 'registry'
+  _IMG_REGISTRY: 'null-registry'
   _IMG_VERSION: 'v0.0.0-1'
 
 tags:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ options:
   machineType: N1_HIGHCPU_32
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
+- name: 'gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default'
   entrypoint: make
   env:
   - GIT_TAG=$_GIT_TAG


### PR DESCRIPTION
Part of https://github.com/kubernetes/publishing-bot/issues/272.

- Add GCB config for image building
- cloudbuild.yaml: Use k8s-ci-builder:latest-default
- cloudbuild.yaml: Ensure images are pushed after build
- cloudbuild.yaml: Wire up image tagging
- cloudbuild.yaml: Use IMG_REGISTRY to determine push registry
- cloudbuild.yaml: Drop unnecessary variables

Signed-off-by: Stephen Augustus <foo@auggie.dev>