### PR TITLE
Lint all the things

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,186 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # - cyclop
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - ifshort
+    # - lll
+    # - nestif
+    # - nilerr
+    # - nlreturn
+    # - noctx
+    # - paralleltest
+    # - scopelint
+    # - tagliatelle
+    # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
+    # - wsl
+linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+      # - ifElseChain
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,8 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    - gosec
+    # TODO(lint): Enable after fixing other lint warnings
+    #- gosec
     - gosimple
     - govet
     - importas

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,8 @@ linters:
     - gocyclo
     - godox
     - gofmt
-    - gofumpt
+    # TODO(lint): Enable once using newer version of golangci-lint
+    #- gofumpt
     - goheader
     - goimports
     - gomoddirectives

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,15 +123,18 @@ linters-settings:
       - offBy1
       - sloppyReassign
       - weakCond
-      - octalLiteral
+      # TODO(lint): Temporarily disabled for compat with older Golang versions
+      #- octalLiteral
 
       # Performance
       - appendCombine
       - equalFold
-      - hugeParam
+      # TODO(lint): Temporarily disabled to prevent pointer handling issues
+      #- hugeParam
       - indexAlloc
       - rangeExprCopy
-      - rangeValCopy
+      # TODO(lint): Temporarily disabled to prevent pointer handling issues
+      #- rangeValCopy
 
       # Style
       - assignOp

--- a/cmd/collapsed-kube-commit-mapper/main.go
+++ b/cmd/collapsed-kube-commit-mapper/main.go
@@ -101,15 +101,15 @@ func main() {
 	}
 
 	// get first-parent commit list of upstream branch
-	kUpstreamBranch, err := r.ResolveRevision(plumbing.Revision(*sourceBranch))
+	srcUpstreamBranch, err := r.ResolveRevision(plumbing.Revision(*sourceBranch))
 	if err != nil {
 		glog.Fatalf("Failed to open upstream branch %s: %v", *sourceBranch, err)
 	}
-	kHead, err := cache.CommitObject(r, *kUpstreamBranch)
+	srcHead, err := cache.CommitObject(r, *srcUpstreamBranch)
 	if err != nil {
 		glog.Fatalf("Failed to open upstream branch %s head: %v", *sourceBranch, err)
 	}
-	kFirstParents, err := git.FirstParentList(r, kHead)
+	srcFirstParents, err := git.FirstParentList(r, srcHead)
 	if err != nil {
 		glog.Fatalf("Failed to get upstream branch %s first-parent list: %v", *sourceBranch, err)
 	}
@@ -120,7 +120,7 @@ func main() {
 		glog.Fatalf("Failed to get first-parent commit list for %s: %v", dstHead.Hash, err)
 	}
 
-	sourceCommitToDstCommits, err := git.SourceCommitToDstCommits(r, *commitMsgTag, dstFirstParents, kFirstParents)
+	sourceCommitToDstCommits, err := git.SourceCommitToDstCommits(r, *commitMsgTag, dstFirstParents, srcFirstParents)
 	if err != nil {
 		glog.Fatalf("Failed to map upstream branch %s to HEAD: %v", *sourceBranch, err)
 	}

--- a/cmd/gomod-zip/zip.go
+++ b/cmd/gomod-zip/zip.go
@@ -49,6 +49,8 @@ Usage: %s --package-name <package-name> --pseudo-version <pseudo-version>
 func main() {
 	packageName := flag.String("package-name", "", "package to zip")
 	pseudoVersion := flag.String("pseudo-version", "", "pseudoVersion to zip at")
+
+	flag.Usage = Usage
 	flag.Parse()
 
 	if *packageName == "" {

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -143,9 +143,9 @@ func cloneForkRepo(cfg config.Config, repoName string) {
 
 	if _, err := os.Stat(repoDir); err == nil {
 		glog.Infof("Fork repository %q already cloned to %s, resetting remote URL ...", repoName, repoDir)
-		setUrlCmd := exec.Command("git", "remote", "set-url", "origin", forkRepoLocation)
-		setUrlCmd.Dir = repoDir
-		run(setUrlCmd)
+		setURLCmd := exec.Command("git", "remote", "set-url", "origin", forkRepoLocation)
+		setURLCmd.Dir = repoDir
+		run(setURLCmd)
 		os.Remove(filepath.Join(repoDir, ".git", "index.lock"))
 	} else {
 		glog.Infof("Cloning fork repository %s ...", forkRepoLocation)

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -103,11 +103,11 @@ func main() {
 		cfg.RulesFile = *rulesFile
 	}
 
-	if len(cfg.SourceRepo) == 0 || len(cfg.SourceOrg) == 0 {
+	if cfg.SourceRepo == "" || cfg.SourceOrg == "" {
 		glog.Fatalf("source-org and source-repo cannot be empty")
 	}
 
-	if len(cfg.TargetOrg) == 0 {
+	if cfg.TargetOrg == "" {
 		glog.Fatalf("Target organization cannot be empty")
 	}
 
@@ -116,7 +116,7 @@ func main() {
 		cfg.RulesFile = filepath.Join(BaseRepoPath, cfg.SourceRepo, os.Getenv("RULE_FILE_PATH"))
 	}
 
-	if len(cfg.RulesFile) == 0 {
+	if cfg.RulesFile == "" {
 		glog.Fatalf("No rules file provided")
 	}
 	rules, err := config.LoadRules(cfg.RulesFile)
@@ -166,7 +166,7 @@ func cloneForkRepo(cfg config.Config, repoName string) {
 func run(c *exec.Cmd) {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	if len(c.Dir) == 0 {
+	if c.Dir == "" {
 		c.Dir = BaseRepoPath
 	}
 	if err := c.Run(); err != nil {

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -87,9 +87,9 @@ type RepositoryRules struct {
 func LoadRules(ruleFile string) (*RepositoryRules, error) {
 	var content []byte
 
-	if ruleUrl, err := url.ParseRequestURI(ruleFile); err == nil && len(ruleUrl.Host) > 0 {
-		glog.Infof("loading rules file from url : %s", ruleUrl)
-		content, err = readFromUrl(ruleUrl)
+	if ruleURL, err := url.ParseRequestURI(ruleFile); err == nil && len(ruleURL.Host) > 0 {
+		glog.Infof("loading rules file from url : %s", ruleURL)
+		content, err = readFromURL(ruleURL)
 		if err != nil {
 			return nil, err
 		}
@@ -109,8 +109,8 @@ func LoadRules(ruleFile string) (*RepositoryRules, error) {
 	return &rules, nil
 }
 
-// readFromUrl reads the rule file from provided URL.
-func readFromUrl(u *url.URL) ([]byte, error) {
+// readFromURL reads the rule file from provided URL.
+func readFromURL(u *url.URL) ([]byte, error) {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -98,7 +98,6 @@ func LoadRules(ruleFile string) (*RepositoryRules, error) {
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	var rules RepositoryRules

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -23,7 +23,7 @@ type Dependency struct {
 
 func (c Dependency) String() string {
 	repo := c.Repository
-	if len(repo) == 0 {
+	if repo == "" {
 		repo = "<source>"
 	}
 	return fmt.Sprintf("[repository %s, branch %s]", repo, c.Branch)
@@ -39,7 +39,7 @@ type Source struct {
 
 func (c Source) String() string {
 	repo := c.Repository
-	if len(repo) == 0 {
+	if repo == "" {
 		repo = "<source>"
 	}
 	return fmt.Sprintf("[repository %s, branch %s, subdir %s]", repo, c.Branch, c.Dir)
@@ -85,13 +85,14 @@ type RepositoryRules struct {
 // LoadRules loads the repository rules either from the remote HTTP location or
 // a local file path.
 func LoadRules(ruleFile string) (*RepositoryRules, error) {
-	var (
-		content []byte
-		err     error
-	)
+	var content []byte
+
 	if ruleUrl, err := url.ParseRequestURI(ruleFile); err == nil && len(ruleUrl.Host) > 0 {
 		glog.Infof("loading rules file from url : %s", ruleUrl)
 		content, err = readFromUrl(ruleUrl)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		glog.Infof("loading rules file : %s", ruleFile)
 		content, err = ioutil.ReadFile(ruleFile)
@@ -101,9 +102,10 @@ func LoadRules(ruleFile string) (*RepositoryRules, error) {
 	}
 
 	var rules RepositoryRules
-	if err = yaml.Unmarshal(content, &rules); err != nil {
+	if err := yaml.Unmarshal(content, &rules); err != nil {
 		return nil, err
 	}
+
 	return &rules, nil
 }
 

--- a/cmd/publishing-bot/config/rules_test.go
+++ b/cmd/publishing-bot/config/rules_test.go
@@ -64,5 +64,4 @@ func TestValidateGoVersion(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/cmd/publishing-bot/github.go
+++ b/cmd/publishing-bot/github.go
@@ -42,7 +42,8 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 	client := githubClient(token)
 
 	// filter out token, if it happens to be in the log (it shouldn't!)
-	logs = strings.Replace(logs, token, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -1)
+	// TODO: Consider using log sanitizer from sigs.k8s.io/release-utils
+	logs = strings.ReplaceAll(logs, token, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
 
 	// who am I?
 	myself, resp, err := client.Users.Get(ctx, "")

--- a/cmd/publishing-bot/github.go
+++ b/cmd/publishing-bot/github.go
@@ -118,7 +118,7 @@ func CloseIssue(token, org, repo string, issue int) error {
 
 func transfromLogToGithubFormat(original string, maxLines int, headings ...string) string {
 	logCount := 0
-	transformed := NewLogBuilderWithMaxBytes(65000, original).
+	transformed := newLogBuilderWithMaxBytes(65000, original).
 		AddHeading(headings...).
 		AddHeading("```").
 		Trim("\n").

--- a/cmd/publishing-bot/log_builder.go
+++ b/cmd/publishing-bot/log_builder.go
@@ -33,7 +33,7 @@ func NewLogBuilderWithMaxBytes(maxBytes int, rawLogs ...string) *logBuilder {
 	for i := len(rawLogs) - 1; i >= 0; i-- {
 		if curSize := size + len(rawLogs[i]); !ignoreBytesLimits && curSize > maxBytes {
 			rawLogs[i] = rawLogs[i][curSize-maxBytes:]
-			rawLogs[i] = "..." + string(rawLogs[i][3:])
+			rawLogs[i] = "..." + rawLogs[i][3:]
 			logBuilder.logs = append(logBuilder.logs, rawLogs[i])
 			break
 		}

--- a/cmd/publishing-bot/log_builder.go
+++ b/cmd/publishing-bot/log_builder.go
@@ -26,7 +26,7 @@ type logBuilder struct {
 	tailings []string
 }
 
-func NewLogBuilderWithMaxBytes(maxBytes int, rawLogs ...string) *logBuilder {
+func newLogBuilderWithMaxBytes(maxBytes int, rawLogs ...string) *logBuilder {
 	ignoreBytesLimits := maxBytes <= 0
 	size := 0
 	logBuilder := &logBuilder{}

--- a/cmd/publishing-bot/log_builder_test.go
+++ b/cmd/publishing-bot/log_builder_test.go
@@ -48,7 +48,7 @@ func TestNewGithubLogBuilder(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		builder := NewLogBuilderWithMaxBytes(c.maxBytes, c.rawLog)
+		builder := newLogBuilderWithMaxBytes(c.maxBytes, c.rawLog)
 		if l := builder.Log(); l != c.expectedLog {
 			t.Errorf("log mismatched: expected(%q) actual(%q)", c.expectedLog, l)
 			t.Fail()
@@ -67,7 +67,7 @@ barbarbar
 foobarfoo
 foobaz
 fooworld`
-	actual := NewLogBuilderWithMaxBytes(0, testLog).
+	actual := newLogBuilderWithMaxBytes(0, testLog).
 		AddHeading("****").
 		Trim("\n").
 		Split("\n").

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -21,16 +21,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	"gopkg.in/yaml.v2"
-
-	"strings"
-
-	"time"
-
-	"path/filepath"
 
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -42,6 +42,8 @@ Command line flags override config values.
 	flag.PrintDefaults()
 }
 
+// TODO(lint): cyclomatic complexity 38 of func `main` is high (> 30)
+// nolint: gocyclo
 func main() {
 	configFilePath := flag.String("config", "", "the config file in yaml format")
 	githubHost := flag.String("github-host", "", "the address of github (defaults to github.com)")

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -112,11 +112,11 @@ func main() {
 		glog.Fatalf("Failed to get absolute path for base-publish-script-path %q: %v", cfg.BasePublishScriptPath, err)
 	}
 
-	if len(cfg.SourceRepo) == 0 || len(cfg.SourceOrg) == 0 {
+	if cfg.SourceRepo == "" || cfg.SourceOrg == "" {
 		glog.Fatalf("source-org and source-repo cannot be empty")
 	}
 
-	if len(cfg.TargetOrg) == 0 {
+	if cfg.TargetOrg == "" {
 		glog.Fatalf("Target organization cannot be empty")
 	}
 
@@ -137,7 +137,7 @@ func main() {
 		cfg.RulesFile = filepath.Join(baseRepoPath, cfg.SourceRepo, os.Getenv("RULE_FILE_PATH"))
 	}
 
-	if len(cfg.RulesFile) == 0 {
+	if cfg.RulesFile == "" {
 		glog.Fatalf("No rules file provided")
 	}
 

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -193,7 +193,7 @@ func (p *PublisherMunger) ensureCloned(dst string, dstURL string) error {
 }
 
 func (p *PublisherMunger) runSmokeTests(smokeTest, oldHead, newHead string, branchEnv []string) error {
-	if len(smokeTest) > 0 && string(oldHead) != string(newHead) {
+	if len(smokeTest) > 0 && oldHead != newHead {
 		cmd := exec.Command("/bin/bash", "-xec", smokeTest)
 		cmd.Env = append([]string(nil), branchEnv...) // make mutable
 		cmd.Env = append(cmd.Env, "GO111MODULE=on")

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -406,7 +406,7 @@ func publishedFileName(repo, branch string) string {
 // Run constructs the repos and pushes them. It returns logs and the last master hash.
 func (p *PublisherMunger) Run() (logs, masterHead string, err error) {
 	buf := bytes.NewBuffer(nil)
-	if p.plog, err = NewPublisherLog(buf, path.Join(p.baseRepoPath, "run.log")); err != nil {
+	if p.plog, err = newPublisherLog(buf, path.Join(p.baseRepoPath, "run.log")); err != nil {
 		return "", "", err
 	}
 

--- a/cmd/publishing-bot/publisher_logger.go
+++ b/cmd/publishing-bot/publisher_logger.go
@@ -123,7 +123,7 @@ type cmdStr exec.Cmd
 func (cs cmdStr) String() string {
 	args := make([]string, len(cs.Args))
 	for i, s := range cs.Args {
-		if strings.IndexRune(s, ' ') != -1 {
+		if strings.ContainsRune(s, ' ') {
 			args[i] = fmt.Sprintf("%q", s)
 		} else {
 			args[i] = s

--- a/cmd/publishing-bot/publisher_logger.go
+++ b/cmd/publishing-bot/publisher_logger.go
@@ -40,7 +40,7 @@ type plog struct {
 	buf                *bytes.Buffer
 }
 
-func NewPublisherLog(buf *bytes.Buffer, logFileName string) (*plog, error) {
+func newPublisherLog(buf *bytes.Buffer, logFileName string) (*plog, error) {
 	logFile := &lumberjack.Logger{
 		Filename: logFileName,
 		MaxAge:   7,

--- a/cmd/publishing-bot/publisher_logger.go
+++ b/cmd/publishing-bot/publisher_logger.go
@@ -53,8 +53,16 @@ func newPublisherLog(buf *bytes.Buffer, logFileName string) (*plog, error) {
 }
 
 func (p *plog) write(s string) {
+	// TODO(lint): Should we be checking errors here?
+	// nolint: errcheck
 	p.combinedBufAndFile.Write([]byte("[" + time.Now().Format(time.RFC822) + "]: "))
+
+	// TODO(lint): Should we be checking errors here?
+	// nolint: errcheck
 	p.combinedBufAndFile.Write([]byte(s))
+
+	// TODO(lint): Should we be checking errors here?
+	// nolint: errcheck
 	p.combinedBufAndFile.Write([]byte("\n"))
 }
 

--- a/cmd/publishing-bot/publisher_logger.go
+++ b/cmd/publishing-bot/publisher_logger.go
@@ -173,6 +173,8 @@ func (lw lineWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+// TODO(lint): result 0 (int) is never used
+// nolint: unparam
 func (lw lineWriter) Flush() (int, error) {
 	written, err := lw.buf.WriteTo(lw.writer)
 	lw.buf.Reset()

--- a/cmd/publishing-bot/publisher_logger_test.go
+++ b/cmd/publishing-bot/publisher_logger_test.go
@@ -18,17 +18,15 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"sync"
 	"testing"
 )
 
 func TestLogLineWriter(t *testing.T) {
-
 	buf := new(bytes.Buffer)
-
-	var fakeLogWriter io.Writer
-	fakeLogWriter = newSyncWriter(muxWriter{buf})
+	fakeLogWriter := newSyncWriter(
+		muxWriter{buf},
+	)
 
 	content1 := "XXXXXXXXXXXXXX"
 	content2 := "YYYYYYYYYYYYYY"
@@ -69,5 +67,4 @@ func TestLogLineWriter(t *testing.T) {
 			t.Fail()
 		}
 	}
-
 }

--- a/cmd/publishing-bot/publisher_logger_test.go
+++ b/cmd/publishing-bot/publisher_logger_test.go
@@ -53,7 +53,7 @@ func TestLogLineWriter(t *testing.T) {
 	finalContent := buf.String()
 	uniqueLines := make(map[string]struct{})
 
-	NewLogBuilderWithMaxBytes(0, finalContent).
+	newLogBuilderWithMaxBytes(0, finalContent).
 		Trim("\n").
 		Split("\n").
 		Filter(func(line string) bool {

--- a/cmd/publishing-bot/publisher_logger_test.go
+++ b/cmd/publishing-bot/publisher_logger_test.go
@@ -43,6 +43,8 @@ func TestLogLineWriter(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			for i := 0; i < 99999; i++ {
+				// TODO(lint): Should we be checking errors here?
+				// nolint: errcheck
 				w.Write([]byte(content + "\n"))
 			}
 			wg.Done()

--- a/cmd/publishing-bot/publisher_test.go
+++ b/cmd/publishing-bot/publisher_test.go
@@ -26,8 +26,10 @@ func Test_updateEnv(t *testing.T) {
 		name string
 		env  []string
 		want []string
-	}{
-		//{"no PATH", []string{"FOO=42"}, []string{"FOO=42", "PATH=/usr/local/go"}},
+	}{ // TODO: Fix or remove
+		/*
+			{"no PATH", []string{"FOO=42"}, []string{"FOO=42", "PATH=/usr/local/go"}},
+		*/
 		{"no PATH", []string{"FOO=42", "PATH=/bin", "BAR=1"}, []string{"FOO=42", "PATH=/usr/local/go:/bin", "BAR=1"}},
 	}
 	for _, tt := range tests {

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -90,6 +90,9 @@ func (h *Server) runHandler(w http.ResponseWriter, r *http.Request) {
 	case h.RunChan <- true:
 	default:
 	}
+
+	// TODO(lint): Should we be checking errors here?
+	// nolint: errcheck
 	w.Write([]byte("OK"))
 }
 
@@ -108,5 +111,8 @@ func (h *Server) healthzHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// TODO(lint): Should we be checking errors here?
+	// nolint: errcheck
 	w.Write(bytes)
 }

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -66,6 +66,8 @@ func (h *Server) SetHealth(healthy bool, hash string) {
 	}
 }
 
+// TODO(lint): result 0 (error) is always nil
+// nolint: unparam
 func (h *Server) Run(port int) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthzHandler)

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -128,7 +128,7 @@ func depsImportPaths(depsRepo []string) (string, error) {
 	d := strings.Split(dir, "/")
 	basePackage := d[len(d)-2]
 
-	var depImportPathList []string
+	depImportPathList := []string{}
 	for _, dep := range depsRepo {
 		depImportPathList = append(depImportPathList, fmt.Sprintf("%s/%s", basePackage, dep))
 	}
@@ -156,7 +156,7 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag string, 
 	fmt.Printf("Packaging up %s for %s into go mod cache.\n", pseudoVersionOrTag, depPkg)
 
 	// create the cache if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(goModFile), os.FileMode(755)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(goModFile), os.FileMode(0755)); err != nil {
 		return fmt.Errorf("unable to create %s directory: %v", cacheDir, err)
 	}
 

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -262,7 +262,7 @@ func copyFile(src, dst string) error {
 // fullPackageName return the Golang full package name of dir inside the ${GOPATH}/src.
 func fullPackageName(dir string) (string, error) {
 	gopath := os.Getenv("GOPATH")
-	if len(gopath) == 0 {
+	if gopath == "" {
 		return "", fmt.Errorf("GOPATH is not set")
 	}
 

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -150,7 +150,7 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag string, 
 		fmt.Printf("%s for %s is already packaged up.\n", pseudoVersionOrTag, depPkg)
 		return nil
 	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Could not check if %s exists: %v", goModFile, err)
+		return fmt.Errorf("could not check if %s exists: %v", goModFile, err)
 	}
 
 	fmt.Printf("Packaging up %s for %s into go mod cache.\n", pseudoVersionOrTag, depPkg)

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -211,7 +211,8 @@ func main() {
 
 		// ignore old tags
 		if tag.Tagger.When.Before(time.Date(2017, 9, 1, 0, 0, 0, 0, time.UTC)) {
-			//fmt.Printf("Ignoring old tag origin/%s from %v\n", bName, tag.Tagger.When)
+			// TODO: Fix or remove
+			// fmt.Printf("Ignoring old tag origin/%s from %v\n", bName, tag.Tagger.When)
 			continue
 		}
 
@@ -429,9 +430,12 @@ func tagExists(tag string) bool {
 	return cmd.Run() == nil
 
 	// TODO: Fix or remove
+	// nolint: gocritic
 	// the following does not work with go-git, for unknown reasons:
-	//_, err := r.ResolveRevision(plumbing.Revision(fmt.Sprintf("refs/tags/%s", tag)))
-	//return err == nil
+	/*
+		_, err := r.ResolveRevision(plumbing.Revision(fmt.Sprintf("refs/tags/%s", tag)))
+		return err == nil
+	*/
 }
 
 func fetchTags(r *gogit.Repository, remote string) error {
@@ -464,7 +468,7 @@ func writeKubeCommitMapping(w io.Writer, r *gogit.Repository, m map[plumbing.Has
 	return nil
 }
 
-func mappingOutputFileName(fnameTpl string, branch, tag string) string {
+func mappingOutputFileName(fnameTpl, branch, tag string) string {
 	tpl, err := template.New("mapping-output-file").Parse(fnameTpl)
 	if err != nil {
 		glog.Fatal(err)

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -401,6 +401,8 @@ func removeRemoteTags(r *gogit.Repository, remotes ...string) error {
 		n := ref.Name().String()
 		for _, remote := range remotes {
 			if strings.HasPrefix(n, "refs/tags/"+remote+"/") {
+				// TODO(lint): Should we be checking errors here?
+				// nolint: errcheck
 				r.Storer.RemoveReference(ref.Name())
 				break
 			}

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -65,6 +65,8 @@ var publishingBot = object.Signature{
 	Email: os.Getenv("GIT_COMMITTER_EMAIL"),
 }
 
+// TODO(lint): cyclomatic complexity 63 of func `main` is high (> 30)
+// nolint: gocyclo
 func main() {
 	// repository flags used when the repository is not k8s.io/kubernetes
 	commitMsgTag := flag.String("commit-message-tag", "Kubernetes-commit", "the git commit message tag used to point back to source commits")

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -292,7 +292,7 @@ func main() {
 				if err != nil {
 					glog.Fatal(f)
 				}
-				if err := writeKubeCommitMapping(f, r, sourceCommitsToDstCommits, srcFirstParents); err != nil {
+				if err := writeKubeCommitMapping(f, sourceCommitsToDstCommits, srcFirstParents); err != nil {
 					glog.Fatal(err)
 				}
 				defer f.Close()
@@ -455,7 +455,7 @@ func fetchTags(r *gogit.Repository, remote string) error {
 	return err
 }
 
-func writeKubeCommitMapping(w io.Writer, r *gogit.Repository, m map[plumbing.Hash]plumbing.Hash, srcFirstParents []*object.Commit) error {
+func writeKubeCommitMapping(w io.Writer, m map[plumbing.Hash]plumbing.Hash, srcFirstParents []*object.Commit) error {
 	for _, kc := range srcFirstParents {
 		msg := strings.SplitN(kc.Message, "\n", 2)[0]
 		var err error

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -411,11 +411,11 @@ func removeRemoteTags(r *gogit.Repository, remotes ...string) error {
 func createAnnotatedTag(h plumbing.Hash, name string, date time.Time, message string) error {
 	setUsernameCmd := exec.Command("git", "config", "user.name", publishingBot.Name)
 	if err := setUsernameCmd.Run(); err != nil {
-		return fmt.Errorf("Unable to set global configuration: %v", err)
+		return fmt.Errorf("unable to set global configuration: %v", err)
 	}
 	setEmailCmd := exec.Command("git", "config", "user.email", publishingBot.Email)
 	if err := setEmailCmd.Run(); err != nil {
-		return fmt.Errorf("Unable to set global configuration: %v", err)
+		return fmt.Errorf("unable to set global configuration: %v", err)
 	}
 	cmd := exec.Command("git", "tag", "-a", "-m", message, name, h.String())
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_COMMITTER_DATE=%s", date.Format(rfc2822)))
@@ -478,7 +478,8 @@ func mappingOutputFileName(fnameTpl string, branch, tag string) string {
 	}); err != nil {
 		glog.Fatal(err)
 	}
-	return string(buf.Bytes())
+
+	return buf.String()
 }
 
 func checkoutBranchTagCommit(r *gogit.Repository, bh plumbing.Hash, dependentRepos []string) *gogit.Worktree {

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -224,7 +224,7 @@ func main() {
 
 		// if any of the tag exists locally,
 		// delete the tags, clear the cache and recreate them
-		if tagExists(r, bName) {
+		if tagExists(bName) {
 			commit, commitTime, err := taggedCommitHashAndTime(r, bName)
 			if err != nil {
 				glog.Fatalf("Failed to get tag %s: %v", bName, err)
@@ -242,7 +242,7 @@ func main() {
 			}
 		}
 
-		if publishSemverTag && tagExists(r, semverTag) {
+		if publishSemverTag && tagExists(semverTag) {
 			fmt.Printf("Clearing cache for local tag %s.\n", semverTag)
 			if err := cleanCacheForTag(semverTag); err != nil {
 				glog.Fatalf("Failed to clean go mod cache for %s: %v", semverTag, err)
@@ -424,10 +424,11 @@ func createAnnotatedTag(h plumbing.Hash, name string, date time.Time, message st
 	return cmd.Run()
 }
 
-func tagExists(r *gogit.Repository, tag string) bool {
+func tagExists(tag string) bool {
 	cmd := exec.Command("git", "show-ref", fmt.Sprintf("refs/tags/%s", tag))
 	return cmd.Run() == nil
 
+	// TODO: Fix or remove
 	// the following does not work with go-git, for unknown reasons:
 	//_, err := r.ResolveRevision(plumbing.Revision(fmt.Sprintf("refs/tags/%s", tag)))
 	//return err == nil

--- a/cmd/validate-rules/main.go
+++ b/cmd/validate-rules/main.go
@@ -27,7 +27,10 @@ import (
 
 func main() {
 	flag.Parse()
-	flag.Set("alsologtostderr", "true")
+	err := flag.Set("alsologtostderr", "true")
+	if err != nil {
+		glog.Fatalf("attempting to log to stderr: %v", err)
+	}
 
 	for _, f := range flag.Args() {
 		rules, err := config.LoadRules(f)

--- a/cmd/validate-rules/main.go
+++ b/cmd/validate-rules/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+
 	"github.com/golang/glog"
+
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 	"k8s.io/publishing-bot/cmd/validate-rules/staging"
 )

--- a/cmd/validate-rules/staging/github_utils.go
+++ b/cmd/validate-rules/staging/github_utils.go
@@ -61,9 +61,9 @@ func fetchKubernetesStagingDirectoryFiles(branch string) ([]File, error) {
 			// try for 10 mins then give up!
 			if count == 120 {
 				return nil, fmt.Errorf("hitting github API limits, bailing out")
-			} else {
-				break
 			}
+
+			break
 		}
 	}
 

--- a/cmd/validate-rules/staging/validate.go
+++ b/cmd/validate-rules/staging/validate.go
@@ -18,9 +18,11 @@ package staging
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 	"path/filepath"
+
+	"github.com/golang/glog"
+
+	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
 // globalMapBranchDirectories is a cache to avoid hitting GH limits

--- a/cmd/validate-rules/staging/validate.go
+++ b/cmd/validate-rules/staging/validate.go
@@ -55,7 +55,7 @@ func EnsureStagingDirectoriesExist(rules *config.RepositoryRules) []error {
 	return errors
 }
 
-func checkDirectoryExistsInBranch(directory string, branch string) error {
+func checkDirectoryExistsInBranch(directory, branch string) error {
 	// Look in the cache first
 	files, ok := globalMapBranchDirectories[branch]
 	if !ok {

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION=v1.42.0
+URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
+URL=$URL_BASE/$VERSION/install.sh
+
+if [[ ! -f .golangci.yml ]]; then
+    echo 'ERROR: missing .golangci.yml in repo root' >&2
+    exit 1
+fi
+
+if ! command -v golangci-lint; then
+    curl -sfL $URL | sh -s $VERSION
+    PATH=$PATH:bin
+fi
+
+golangci-lint version
+golangci-lint linters
+golangci-lint run "$@"

--- a/pkg/git/mapping.go
+++ b/pkg/git/mapping.go
@@ -42,9 +42,9 @@ import (
 //     |-B
 //      `A - initial commit
 //
-func SourceCommitToDstCommits(r *gogit.Repository, commitMsgTag string, dstFirstParents, kFirstParents []*object.Commit) (map[plumbing.Hash]plumbing.Hash, error) {
+func SourceCommitToDstCommits(r *gogit.Repository, commitMsgTag string, dstFirstParents, srcFirstParents []*object.Commit) (map[plumbing.Hash]plumbing.Hash, error) {
 	// compute merge point table
-	kubeMergePoints, err := MergePoints(r, kFirstParents)
+	kubeMergePoints, err := MergePoints(r, srcFirstParents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build merge point table: %v", err)
 	}
@@ -73,8 +73,8 @@ func SourceCommitToDstCommits(r *gogit.Repository, commitMsgTag string, dstFirst
 	// fill up mainlineKubeHashes in dstMainlineCommits with collapsed kube commits
 	dst := firstDstCommit
 	kubeHashToDstMainLineHash := map[plumbing.Hash]plumbing.Hash{}
-	for i := len(kFirstParents) - 1; i >= 0; i-- {
-		kc := kFirstParents[i]
+	for i := len(srcFirstParents) - 1; i >= 0; i-- {
+		kc := srcFirstParents[i]
 		if dh, found := directKubeHashToDstMainLineHash[kc.Hash]; found {
 			dst = dh
 		}

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -78,7 +78,7 @@ func InstallGoVersions(rules *config.RepositoryRules) error {
 	return nil
 }
 
-func installGoVersion(v string, pth string) error {
+func installGoVersion(v, pth string) error {
 	if s, err := os.Stat(pth); err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err == nil {


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <foo@auggie.dev>

Initial results:

```console
❯ ./hack/verify-golangci-lint.sh
```

<details>

```console
/usr/local/bin/golangci-lint
golangci-lint has version 1.43.0 built from 861262b on 2021-11-02T20:54:42Z
Enabled by your configuration linters:
asciicheck: Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
bodyclose: checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
deadcode: Finds unused code [fast: false, auto-fix: false]
depguard: Go linter that checks if package imports are in a list of acceptable packages [fast: false, auto-fix: false]
dogsled: Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
dupl: Tool for code clone detection [fast: true, auto-fix: false]
durationcheck: check for two durations multiplied together [fast: false, auto-fix: false]
errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
goconst: Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
gocritic: Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
gocyclo: Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
godox: Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
gofumpt: Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
goheader: Checks is file header matches to pattern [fast: true, auto-fix: false]
goimports: In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
gomoddirectives: Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
gomodguard: Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
goprintffuncname: Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
gosec (gas): Inspects source code for security problems [fast: false, auto-fix: false]
gosimple (megacheck): Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
importas: Enforces consistent import aliases [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
makezero: Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
misspell: Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
nakedret: Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
nolintlint: Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
prealloc: Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
predeclared: find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
promlinter: Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
revive: Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
rowserrcheck: checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
sqlclosecheck: Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
staticcheck (megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
structcheck: Finds unused struct fields [fast: false, auto-fix: false]
stylecheck: Stylecheck is a replacement for golint [fast: false, auto-fix: false]
typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
unconvert: Remove unnecessary type conversions [fast: false, auto-fix: false]
unparam: Reports unused function parameters [fast: false, auto-fix: false]
unused (megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
varcheck: Finds unused global variables and constants [fast: false, auto-fix: false]
whitespace: Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]

Disabled by your configuration linters:
bidichk: Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
contextcheck: check the function whether use a non-inherited context [fast: false, auto-fix: false]
cyclop: checks function and package cyclomatic complexity [fast: false, auto-fix: false]
errname: Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
errorlint: errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
exhaustive: check exhaustiveness of enum switch statements [fast: false, auto-fix: false]
exhaustivestruct: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
exportloopref: checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
forbidigo: Forbids identifiers [fast: true, auto-fix: false]
forcetypeassert: finds forced type assertions [fast: true, auto-fix: false]
funlen: Tool for detection of long functions [fast: true, auto-fix: false]
gci: Gci control golang package import order and make it always deterministic. [fast: true, auto-fix: true]
gochecknoglobals: check that no global variables exist [fast: true, auto-fix: false]
gochecknoinits: Checks that no init functions are present in Go code [fast: true, auto-fix: false]
gocognit: Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
godot: Check if comments end in a period [fast: true, auto-fix: true]
goerr113: Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
golint: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
gomnd: An analyzer to detect magic numbers. [fast: true, auto-fix: false]
ifshort: Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
interfacer: Linter that suggests narrower interface types [fast: false, auto-fix: false]
ireturn: Accept Interfaces, Return Concrete Types [fast: false, auto-fix: false]
lll: Reports long lines [fast: true, auto-fix: false]
maligned: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
nestif: Reports deeply nested if statements [fast: true, auto-fix: false]
nilerr: Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
nilnil: Checks that there is no simultaneous return of `nil` error and an invalid value. [fast: false, auto-fix: false]
nlreturn: nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
noctx: noctx finds sending http request without context.Context [fast: false, auto-fix: false]
paralleltest: paralleltest detects missing usage of t.Parallel() method in your Go test [fast: true, auto-fix: false]
scopelint: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
tagliatelle: Checks the struct tags. [fast: true, auto-fix: false]
tenv: tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
testpackage: linter that makes you use a separate _test package [fast: true, auto-fix: false]
thelper: thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
tparallel: tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
varnamelen: checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
wastedassign: wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
wrapcheck: Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
wsl: Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
cmd/init-repo/main.go:169:5: emptyStringTest: replace `len(c.Dir) == 0` with `c.Dir == ""` (gocritic)
	if len(c.Dir) == 0 {
	   ^
cmd/init-repo/main.go:119:5: emptyStringTest: replace `len(cfg.RulesFile) == 0` with `cfg.RulesFile == ""` (gocritic)
	if len(cfg.RulesFile) == 0 {
	   ^
cmd/init-repo/main.go:106:33: emptyStringTest: replace `len(cfg.SourceOrg) == 0` with `cfg.SourceOrg == ""` (gocritic)
	if len(cfg.SourceRepo) == 0 || len(cfg.SourceOrg) == 0 {
	                               ^
cmd/init-repo/main.go:110:5: emptyStringTest: replace `len(cfg.TargetOrg) == 0` with `cfg.TargetOrg == ""` (gocritic)
	if len(cfg.TargetOrg) == 0 {
	   ^
cmd/init-repo/main.go:140:20: hugeParam: cfg is heavy (144 bytes); consider passing it by pointer (gocritic)
func cloneForkRepo(cfg config.Config, repoName string) {
                   ^
cmd/init-repo/main.go:177:22: hugeParam: cfg is heavy (144 bytes); consider passing it by pointer (gocritic)
func cloneSourceRepo(cfg config.Config) {
                     ^
cmd/init-repo/main.go:156:20: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	setUsernameCmd := exec.Command("git", "config", "user.name", os.Getenv("GIT_COMMITTER_NAME"))
	                  ^
cmd/init-repo/main.go:159:17: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	setEmailCmd := exec.Command("git", "config", "user.email", os.Getenv("GIT_COMMITTER_EMAIL"))
	               ^
cmd/init-repo/main.go:146:3: var-naming: var setUrlCmd should be setURLCmd (revive)
		setUrlCmd := exec.Command("git", "remote", "set-url", "origin", forkRepoLocation)
		^
pkg/golang/install.go:81:1: paramTypeCombine: func(v string, pth string) error could be replaced with func(v, pth string) error (gocritic)
func installGoVersion(v string, pth string) error {
^
pkg/golang/install.go:52:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, branch := range rule.Branches {
		^
pkg/golang/install.go:99:9: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("curl -SLf https://storage.googleapis.com/golang/go%s.linux-amd64.tar.gz | tar -xz --strip 1 -C %s", v, tmpPath))
	       ^
cmd/validate-rules/staging/validate.go:56:1: paramTypeCombine: func(directory string, branch string) error could be replaced with func(directory, branch string) error (gocritic)
func checkDirectoryExistsInBranch(directory string, branch string) error {
^
cmd/validate-rules/staging/validate.go:39:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, branchRule := range rule.Branches {
		^
cmd/validate-rules/staging/validate.go:20: File is not `gofumpt`-ed (gofumpt)
	"fmt"
cmd/validate-rules/staging/validate.go:23: File is not `gofumpt`-ed (gofumpt)
	"path/filepath"
cmd/validate-rules/staging/github_utils.go:64:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
			} else {
				break
			}
cmd/publishing-bot/publisher.go:78:14: Error return value of `os.MkdirAll` is not checked (errcheck)
		os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0755)
		           ^
cmd/publishing-bot/publisher.go:205:45: Error return value of `(*os/exec.Cmd).Run` is not checked (errcheck)
		exec.Command("git", "reset", "--hard").Run()
		                                          ^
cmd/publishing-bot/publisher.go:206:53: Error return value of `(*os/exec.Cmd).Run` is not checked (errcheck)
		exec.Command("git", "clean", "-f", "-f", "-d").Run()
		                                                  ^
cmd/publishing-bot/publisher.go:261:13: Error return value of `(*os/exec.Cmd).Output` is not checked (errcheck)
			oldHead, _ := exec.Command("git", "rev-parse", fmt.Sprintf("origin/%s", branchRule.Name)).Output()
			         ^
cmd/publishing-bot/publisher.go:314:13: Error return value of `(*os/exec.Cmd).Output` is not checked (errcheck)
			newHead, _ := exec.Command("git", "rev-parse", "HEAD").Output()
			         ^
cmd/publishing-bot/publisher_logger.go:56:28: Error return value of `p.combinedBufAndFile.Write` is not checked (errcheck)
	p.combinedBufAndFile.Write([]byte("[" + time.Now().Format(time.RFC822) + "]: "))
	                          ^
cmd/publishing-bot/publisher_logger.go:57:28: Error return value of `p.combinedBufAndFile.Write` is not checked (errcheck)
	p.combinedBufAndFile.Write([]byte(s))
	                          ^
cmd/publishing-bot/publisher_logger.go:58:28: Error return value of `p.combinedBufAndFile.Write` is not checked (errcheck)
	p.combinedBufAndFile.Write([]byte("\n"))
	                          ^
cmd/publishing-bot/publisher_logger_test.go:48:12: Error return value of `w.Write` is not checked (errcheck)
				w.Write([]byte(content + "\n"))
				       ^
cmd/publishing-bot/server.go:91:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte("OK"))
	       ^
cmd/publishing-bot/server.go:109:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write(bytes)
	       ^
cmd/publishing-bot/github.go:45:9: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(logs, token, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -1)` (gocritic)
	logs = strings.Replace(logs, token, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", -1)
	       ^
cmd/publishing-bot/main.go:143:5: emptyStringTest: replace `len(cfg.RulesFile) == 0` with `cfg.RulesFile == ""` (gocritic)
	if len(cfg.RulesFile) == 0 {
	   ^
cmd/publishing-bot/main.go:118:33: emptyStringTest: replace `len(cfg.SourceOrg) == 0` with `cfg.SourceOrg == ""` (gocritic)
	if len(cfg.SourceRepo) == 0 || len(cfg.SourceOrg) == 0 {
	                               ^
cmd/publishing-bot/main.go:122:5: emptyStringTest: replace `len(cfg.TargetOrg) == 0` with `cfg.TargetOrg == ""` (gocritic)
	if len(cfg.TargetOrg) == 0 {
	   ^
cmd/publishing-bot/publisher.go:199:3: appendCombine: can combine chain of 2 appends into one (gocritic)
		cmd.Env = append(cmd.Env, "GO111MODULE=on")
		^
cmd/publishing-bot/publisher.go:255:7: emptyStringTest: replace `len(branchRule.Source.Dir) == 0` with `branchRule.Source.Dir == ""` (gocritic)
			if len(branchRule.Source.Dir) == 0 {
			   ^
cmd/publishing-bot/publisher.go:81:5: octalLiteral: use new octal literal style, 0o644 (gocritic)
`), 0644); err != nil {
    ^
cmd/publishing-bot/publisher.go:391:166: octalLiteral: use new octal literal style, 0o644 (gocritic)
			if err := ioutil.WriteFile(path.Join(path.Dir(dstDir), publishedFileName(repoRules.DestinationRepository, branchRule.Name)), []byte(upstreamBranchHead.String()), 0644); err != nil {
			                                                                                                                                                                  ^
cmd/publishing-bot/publisher.go:177:1: paramTypeCombine: func(dst string, dstURL string) error could be replaced with func(dst, dstURL string) error (gocritic)
func (p *PublisherMunger) ensureCloned(dst string, dstURL string) error {
^
cmd/publishing-bot/publisher.go:251:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, branchRule := range repoRule.Branches {
		^
cmd/publishing-bot/publisher.go:377:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, branchRule := range repoRules.Branches {
		^
cmd/publishing-bot/publisher.go:404:1: unnamedResult: consider giving a name to these results (gocritic)
func (p *PublisherMunger) Run() (string, string, error) {
^
cmd/publishing-bot/publisher_logger.go:123:7: hugeParam: cs is heavy (328 bytes); consider passing it by pointer (gocritic)
func (cs cmdStr) String() string {
      ^
cmd/publishing-bot/publisher_test.go:30:3: commentFormatting: put a space between `//` and comment text (gocritic)
		//{"no PATH", []string{"FOO=42"}, []string{"FOO=42", "PATH=/usr/local/go"}},
		^
cmd/publishing-bot/main.go:48:1: cyclomatic complexity 38 of func `main` is high (> 30) (gocyclo)
func main() {
^
cmd/publishing-bot/main.go:23: File is not `gofumpt`-ed (gofumpt)
	"os"
cmd/publishing-bot/main.go:28: File is not `gofumpt`-ed (gofumpt)

	"strings"

	"time"

	"path/filepath"
cmd/publishing-bot/publisher_logger_test.go:27: File is not `gofumpt`-ed (gofumpt)

cmd/publishing-bot/publisher_logger_test.go:72: File is not `gofumpt`-ed (gofumpt)

cmd/publishing-bot/publisher.go:79:13: G306: Expect WriteFile permissions to be 0600 or less (gosec)
		if err := ioutil.WriteFile(attrFile, []byte(`
* -text
`), 0644); err != nil {
cmd/publishing-bot/publisher.go:382:11: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
			cmd := exec.Command(p.config.BasePublishScriptPath+"/push.sh", p.config.TokenFile, branchRule.Name)
			       ^
cmd/publishing-bot/log_builder.go:29:65: unexported-return: exported func NewLogBuilderWithMaxBytes returns unexported type *main.logBuilder, which can be annoying to use (revive)
func NewLogBuilderWithMaxBytes(maxBytes int, rawLogs ...string) *logBuilder {
                                                                ^
cmd/publishing-bot/publisher_logger.go:43:62: unexported-return: exported func NewPublisherLog returns unexported type *main.plog, which can be annoying to use (revive)
func NewPublisherLog(buf *bytes.Buffer, logFileName string) (*plog, error) {
                                                             ^
cmd/publishing-bot/log_builder.go:36:31: unnecessary conversion (unconvert)
			rawLogs[i] = "..." + string(rawLogs[i][3:])
			                           ^
cmd/publishing-bot/publisher.go:196:33: unnecessary conversion (unconvert)
	if len(smokeTest) > 0 && string(oldHead) != string(newHead) {
	                               ^
cmd/publishing-bot/publisher_logger.go:176:31: (lineWriter).Flush - result 0 (int) is never used (unparam)
func (lw lineWriter) Flush() (int, error) {
                              ^
cmd/publishing-bot/server.go:69:32: (*Server).Run - result 0 (error) is always nil (unparam)
func (h *Server) Run(port int) error {
                               ^
cmd/publishing-bot/publisher_logger_test.go:26: unnecessary leading newline (whitespace)
func TestLogLineWriter(t *testing.T) {

cmd/publishing-bot/publisher_logger_test.go:30:2: S1021: should merge variable declaration with assignment on next line (gosimple)
	var fakeLogWriter io.Writer
	^
cmd/publishing-bot/publisher_logger.go:126:6: S1003: should use strings.ContainsRune(s, ' ') instead (gosimple)
		if strings.IndexRune(s, ' ') != -1 {
		   ^
cmd/publishing-bot/config/rules.go:26:5: emptyStringTest: replace `len(repo) == 0` with `repo == ""` (gocritic)
	if len(repo) == 0 {
	   ^
cmd/publishing-bot/config/rules.go:42:5: emptyStringTest: replace `len(repo) == 0` with `repo == ""` (gocritic)
	if len(repo) == 0 {
	   ^
cmd/publishing-bot/config/rules.go:139:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, br := range r.Branches {
		^
cmd/publishing-bot/config/rules.go:160:3: rangeValCopy: each iteration copies 144 bytes (consider pointers or indexing) (gocritic)
		for _, branch := range rule.Branches {
		^
cmd/publishing-bot/config/rules.go:105:5: sloppyReassign: re-assignment to `err` can be replaced with `err := yaml.Unmarshal(content, &rules)` (gocritic)
	if err = yaml.Unmarshal(content, &rules); err != nil {
	   ^
cmd/publishing-bot/config/rules_test.go:67: File is not `gofumpt`-ed (gofumpt)

cmd/publishing-bot/config/rules.go:114:32: G402: TLS InsecureSkipVerify set true. (gosec)
		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
		                             ^
cmd/publishing-bot/config/rules.go:92:5: var-naming: var ruleUrl should be ruleURL (revive)
	if ruleUrl, err := url.ParseRequestURI(ruleFile); err == nil && len(ruleUrl.Host) > 0 {
	   ^
cmd/publishing-bot/config/rules.go:112:6: var-naming: func readFromUrl should be readFromURL (revive)
func readFromUrl(u *url.URL) ([]byte, error) {
     ^
cmd/publishing-bot/config/rules.go:101: unnecessary trailing newline (whitespace)

	}
cmd/publishing-bot/config/rules.go:94:12: ineffectual assignment to err (ineffassign)
		content, err = readFromUrl(ruleUrl)
		         ^
cmd/collapsed-kube-commit-mapper/main.go:104:2: var-naming: don't use leading k in Go names; var kUpstreamBranch should be upstreamBranch (revive)
	kUpstreamBranch, err := r.ResolveRevision(plumbing.Revision(*sourceBranch))
	^
cmd/collapsed-kube-commit-mapper/main.go:108:2: var-naming: don't use leading k in Go names; var kHead should be head (revive)
	kHead, err := cache.CommitObject(r, *kUpstreamBranch)
	^
cmd/collapsed-kube-commit-mapper/main.go:112:2: var-naming: don't use leading k in Go names; var kFirstParents should be firstParents (revive)
	kFirstParents, err := git.FirstParentList(r, kHead)
	^
cmd/gomod-zip/zip.go:32:6: `Usage` is unused (deadcode)
func Usage() {
     ^
cmd/gomod-zip/zip.go:108:63: octalLiteral: use new octal literal style, 0o644 (gocritic)
	if err := ioutil.WriteFile(zipFilePath, zipContents.Bytes(), 0644); err != nil {
	                                                             ^
pkg/git/mapping.go:45:90: var-naming: don't use leading k in Go names; func parameter kFirstParents should be firstParents (revive)
func SourceCommitToDstCommits(r *gogit.Repository, commitMsgTag string, dstFirstParents, kFirstParents []*object.Commit) (map[plumbing.Hash]plumbing.Hash, error) {
                                                                                         ^
cmd/validate-rules/main.go:28:10: Error return value of `flag.Set` is not checked (errcheck)
	flag.Set("alsologtostderr", "true")
	        ^
cmd/validate-rules/main.go:20: File is not `gofumpt`-ed (gofumpt)
	"flag"
cmd/sync-tags/main.go:403:29: Error return value of `r.Storer.RemoveReference` is not checked (errcheck)
				r.Storer.RemoveReference(ref.Name())
				                        ^
cmd/sync-tags/gomod.go:265:5: emptyStringTest: replace `len(gopath) == 0` with `gopath == ""` (gocritic)
	if len(gopath) == 0 {
	   ^
cmd/sync-tags/gomod.go:189:98: octalLiteral: use new octal literal style, 0o644 (gocritic)
	if err := ioutil.WriteFile(fmt.Sprintf("%s/%s.info", cacheDir, pseudoVersionOrTag), moduleFile, 0644); err != nil {
	                                                                                                ^
cmd/sync-tags/gomod.go:203:102: octalLiteral: use new octal literal style, 0o644 (gocritic)
	listFile, err := os.OpenFile(fmt.Sprintf("%s/list", cacheDir), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
	                                                                                                    ^
cmd/sync-tags/main.go:214:4: commentFormatting: put a space between `//` and comment text (gocritic)
			//fmt.Printf("Ignoring old tag origin/%s from %v\n", bName, tag.Tagger.When)
			^
cmd/sync-tags/main.go:432:2: commentFormatting: put a space between `//` and comment text (gocritic)
	//_, err := r.ResolveRevision(plumbing.Revision(fmt.Sprintf("refs/tags/%s", tag)))
	^
cmd/sync-tags/main.go:358:88: octalLiteral: use new octal literal style, 0o755 (gocritic)
		pushScript, err := os.OpenFile(*pushScriptPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
		                                                                                     ^
cmd/sync-tags/main.go:579:56: octalLiteral: use new octal literal style, 0o644 (gocritic)
		if err := ioutil.WriteFile(listFile, []byte(output), 0644); err != nil {
		                                                     ^
cmd/sync-tags/main.go:466:1: paramTypeCombine: func(fnameTpl string, branch, tag string) string could be replaced with func(fnameTpl, branch, tag string) string (gocritic)
func mappingOutputFileName(fnameTpl string, branch, tag string) string {
^
cmd/sync-tags/main.go:68:1: cyclomatic complexity 63 of func `main` is high (> 30) (gocyclo)
func main() {
^
cmd/sync-tags/gomod.go:74:21: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
		requireCommand := exec.Command("go", "mod", "edit", "-fmt", "-require", fmt.Sprintf("%s@%s", depPkg, pseudoVersionOrTag))
		                  ^
cmd/sync-tags/gomod.go:82:21: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
		replaceCommand := exec.Command("go", "mod", "edit", "-fmt", "-replace", fmt.Sprintf("%s=%s@%s", depPkg, depPkg, pseudoVersionOrTag))
		                  ^
cmd/sync-tags/main.go:412:20: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	setUsernameCmd := exec.Command("git", "config", "user.name", publishingBot.Name)
	                  ^
cmd/sync-tags/main.go:416:17: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	setEmailCmd := exec.Command("git", "config", "user.email", publishingBot.Email)
	               ^
cmd/sync-tags/main.go:420:9: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	cmd := exec.Command("git", "tag", "-a", "-m", message, name, h.String())
	       ^
cmd/sync-tags/main.go:428:9: G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
	cmd := exec.Command("git", "show-ref", fmt.Sprintf("refs/tags/%s", tag))
	       ^
cmd/sync-tags/gomod.go:131:2: Consider preallocating `depImportPathList` (prealloc)
	var depImportPathList []string
	^
cmd/sync-tags/main.go:115:2: var-naming: don't use leading k in Go names; var kUpdateBranch should be updateBranch (revive)
	kUpdateBranch, err := r.ResolveRevision(plumbing.Revision(fmt.Sprintf("refs/remotes/%s/%s", *sourceRemote, *sourceBranch)))
	^
cmd/sync-tags/main.go:119:2: var-naming: don't use leading k in Go names; var kHead should be head (revive)
	kHead, err := cache.CommitObject(r, *kUpdateBranch)
	^
cmd/sync-tags/main.go:123:2: var-naming: don't use leading k in Go names; var kFirstParents should be firstParents (revive)
	kFirstParents, err := git.FirstParentList(r, kHead)
	^
cmd/sync-tags/main.go:144:2: var-naming: don't use leading k in Go names; var kTagCommits should be tagCommits (revive)
	kTagCommits, err := remoteTags(r, *sourceRemote)
	^
cmd/sync-tags/main.go:163:2: var-naming: don't use leading k in Go names; var kFirstParentCommits should be firstParentCommits (revive)
	kFirstParentCommits := map[string]struct{}{}
	^
cmd/sync-tags/main.go:449:98: var-naming: don't use leading k in Go names; func parameter kFirstParents should be firstParents (revive)
func writeKubeCommitMapping(w io.Writer, r *gogit.Repository, m map[plumbing.Hash]plumbing.Hash, kFirstParents []*object.Commit) error {
                                                                                                 ^
cmd/sync-tags/main.go:427:16: `tagExists` - `r` is unused (unparam)
func tagExists(r *gogit.Repository, tag string) bool {
               ^
cmd/sync-tags/main.go:481:9: S1030: should use buf.String() instead of string(buf.Bytes()) (gosimple)
	return string(buf.Bytes())
	       ^
cmd/sync-tags/gomod.go:159:61: SA9002: file mode '755' evaluates to 01363; did you mean '0755'? (staticcheck)
	if err := os.MkdirAll(filepath.Dir(goModFile), os.FileMode(755)); err != nil {
	                                                           ^
cmd/sync-tags/gomod.go:153:10: ST1005: error strings should not be capitalized (stylecheck)
		return fmt.Errorf("Could not check if %s exists: %v", goModFile, err)
		       ^
cmd/sync-tags/main.go:414:10: ST1005: error strings should not be capitalized (stylecheck)
		return fmt.Errorf("Unable to set global configuration: %v", err)
		       ^
cmd/sync-tags/main.go:418:10: ST1005: error strings should not be capitalized (stylecheck)
		return fmt.Errorf("Unable to set global configuration: %v", err)
		       ^
```

</details>