### PR TITLE
.github: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is now enabled for the repo, so let's get it to start updating deps automatically.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @nikhita @sttts 
cc: @kubernetes/publishing-bot-maintainers 