### PR TITLE
Add config option to remove .gitattributes files

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -37,8 +37,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [ ! $# -eq 14 ]; then
-    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name base_package is_library recursive_delete_pattern skip_tags last_published_upstream_hash"
+if [ ! $# -eq 15 ]; then
+    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name base_package is_library recursive_delete_pattern skip_tags last_published_upstream_hash remove_git_attributes"
     exit 1
 fi
 
@@ -74,8 +74,10 @@ RECURSIVE_DELETE_PATTERN="${3}"
 SKIP_TAGS="${4}"
 # last published upstream hash of this branch
 LAST_PUBLISHED_UPSTREAM_HASH="${5}"
+# remove all .gitattributes files
+REMOVE_GIT_ATTRIBUTES="${6}"
 
-readonly REPO SRC_BRANCH DST_BRANCH DEPS REQUIRED SOURCE_REMOTE SOURCE_REPO_ORG SUBDIR SOURCE_REPO_NAME BASE_PACKAGE IS_LIBRARY RECURSIVE_DELETE_PATTERN SKIP_TAGS LAST_PUBLISHED_UPSTREAM_HASH
+readonly REPO SRC_BRANCH DST_BRANCH DEPS REQUIRED SOURCE_REMOTE SOURCE_REPO_ORG SUBDIR SOURCE_REPO_NAME BASE_PACKAGE IS_LIBRARY RECURSIVE_DELETE_PATTERN SKIP_TAGS LAST_PUBLISHED_UPSTREAM_HASH REMOVE_GIT_ATTRIBUTES
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
@@ -129,7 +131,7 @@ if [ "${UPSTREAM_HASH}" != "${LAST_PUBLISHED_UPSTREAM_HASH}" ]; then
     echo "Upstream branch upstream/${SRC_BRANCH} moved from '${LAST_PUBLISHED_UPSTREAM_HASH}' to '${UPSTREAM_HASH}'. We have to sync."
     # sync_repo cherry-picks the commits that change
     # k8s.io/kubernetes/staging/src/k8s.io/${REPO} to the ${DST_BRANCH}
-    sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${DEPS}" "${REQUIRED}" "${BASE_PACKAGE}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}"
+    sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${DEPS}" "${REQUIRED}" "${BASE_PACKAGE}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}" "${REMOVE_GIT_ATTRIBUTES}"
 else
     echo "Skipping sync because upstream/${SRC_BRANCH} at ${UPSTREAM_HASH} did not change since last sync."
 fi

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -66,6 +66,8 @@ type RepositoryRule struct {
 	Library   bool   `yaml:"library,omitempty"`
 	// not updated when true
 	Skip bool `yaml:"skipped,omitempty"`
+	// RemoveGitAttributes removes all .gitattributes files in the repo
+	RemoveGitAttributes *bool `yaml:"remove-git-attributes,omitempty"`
 }
 
 type RepositoryRules struct {

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -237,6 +237,12 @@ func (p *PublisherMunger) construct() error {
 			continue
 		}
 
+		removeGitAttributes := ""
+		if repoRule.RemoveGitAttributes != nil && *repoRule.RemoveGitAttributes {
+			removeGitAttributes = "true"
+			p.plog.Infof("remove-git-attributes is enabled")
+		}
+
 		// clone the destination repo
 		dstDir := filepath.Join(p.baseRepoPath, repoRule.DestinationRepository, "")
 		dstURL := fmt.Sprintf("https://%s/%s/%s.git", p.config.GithubHost, p.config.TargetOrg, repoRule.DestinationRepository)
@@ -319,6 +325,7 @@ func (p *PublisherMunger) construct() error {
 				strings.Join(p.reposRules.RecursiveDeletePatterns, " "),
 				skipTags,
 				lastPublishedUpstreamHash,
+				removeGitAttributes,
 			)
 			cmd.Env = append([]string(nil), branchEnv...) // make mutable
 			if p.reposRules.SkipGomod {


### PR DESCRIPTION
If a staging repo has .gitattributes files containing the `export-subst`
attribute ([example](https://github.com/kubernetes/kubernetes/blob/b6c06a95d7ff262a876b95a1035eaf478a7cb961/staging/src/k8s.io/client-go/pkg/version/.gitattributes)), then git expands the specified placeholders
when git archive is used.

When a published repo is downloaded from GitHub, GitHub does a
"git archive" under the hood. This means that the placeholders get
replaced by their relevant values. This type of "git archive"
application sometimes leads to undesired values. See the example below.

- In client-go, [line 59 in `pkg/version/base.go`](https://github.com/kubernetes/kubernetes/blob/b6c06a95d7ff262a876b95a1035eaf478a7cb961/staging/src/k8s.io/client-go/pkg/version/base.go#L59)
is expanded on a git archive. This line is needed as a fallback to
inject k8s version info for client-go when this info is not provided
via ldflags during builds.

- However, when k/client-go is vendored, the line gets expanded to _the
commit of the project vendoring client-go_ -- which is not helpful at
all! This also means that the vendored client-go will now contain
different (expanded) commit shas for different projects.

- To ensure reproducibility of source, this commit adds an option to
remove the `.gitattributes` files in all published repos.
Additionally, when client-go is used as a library, we don't care about
the line being expanded to inject version info so it is also safe to
remove these files.

The commit adds this feature as a config option in `rules.yaml` so we
can control publishing of `.gitattributes` files for each repo.

---

Ref:
- https://github.com/containerd/containerd/issues/6387#issuecomment-1010019352 (issue found in containerd, cri-o and podman)
- https://github.com/kubernetes/kubernetes/issues/99376#issuecomment-1009881488

---

I have tested this on master for client-go and component-base. The result will look something like this for:
1. client-go - https://github.com/prowtest/client-go/commits/master
2. component-base - https://github.com/prowtest/component-base/commits/master

/hold
Adding a hold because I'd like to ensure tags work fine too. Will do that later this week but wanted to get the PR out for review.

/assign @sttts @dims 