### PR TITLE
Update github token secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ init-deploy: validate
 	while $(KUBECTL) get pod -n "$(NAMESPACE)" publisher -a &>/dev/null; do echo -n .; sleep 1; done
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/storage-class.yaml || true
 	$(KUBECTL) get StorageClass ssd
-	sed 's/TOKEN/$(shell echo "$(TOKEN)" | base64 | tr -d '\n')/g' artifacts/manifests/secret.yaml | $(KUBECTL) apply -n "$(NAMESPACE)" -f -
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-configmap.yaml
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-rules-configmap.yaml; \
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/pvc.yaml

--- a/artifacts/manifests/podspec.yaml
+++ b/artifacts/manifests/podspec.yaml
@@ -67,7 +67,7 @@ volumes:
     name: publisher-rules
 - name: secret-volume
   secret:
-    secretName: github-token
+    secretName: publishing-bot-github-token
 - name: repo
   emptyDir: {}
 - name: cache


### PR DESCRIPTION
We now manage the Github Token with a `ExternalSecret`:
https://github.com/kubernetes/k8s.io/blob/main/apps/publishing-bot/externalsecrets.yaml.
Manual deployment of it is not longer required.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>