### PR TITLE
construct.sh: git prune more aggressively to remove unreachable objects

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -92,6 +92,7 @@ git config user.email "$GIT_COMMITTER_EMAIL"
 git config user.name "$GIT_COMMITTER_NAME"
 
 echo "Running garbage collection."
+git config gc.pruneExpire 3.days.ago
 git gc --auto
 echo "Fetching from origin."
 git fetch origin --no-tags --prune


### PR DESCRIPTION
We perform many history altering commands in the publishing-bot,
which can lead to unreachable loose objects.

`git gc --auto` will try to prune these loose objects. By default, it
will prune loose objects older than 2 weeks. It looks like we have a lot
of unreachable loose objects, so pruning objects older than 2 weeks
still leaves behind enough loose objects ([ref](https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-1120575224)):

```
Running garbage collection.
+ echo 'Running garbage collection.'
+ git gc --auto
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
error: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log.
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.
```

As the warning suggests, we will need to prune these loose objects
first for `git gc --auto` to succeed.

So let us configure git gc to prune objects older than 3 days:

```
git config gc.pruneExpire 3.days.ago
```

Since we run publishing-bot every few hours, we can probably even use an
aggressive expiry period of `1.days.ago` but let us play safe and start
with 3 days ago.

/hold
for review

/assign @sttts 