### PR TITLE
construct.sh: run explicit git prune before git gc

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -91,8 +91,9 @@ fi
 git config user.email "$GIT_COMMITTER_EMAIL"
 git config user.name "$GIT_COMMITTER_NAME"
 
+echo "Running git prune."
+git prune --expire=3.days.ago
 echo "Running garbage collection."
-git config gc.pruneExpire 3.days.ago
 git gc --auto
 echo "Fetching from origin."
 git fetch origin --no-tags --prune


### PR DESCRIPTION
#291 didn't work:

```
 + echo 'Running garbage collection.'
 + git config gc.pruneExpire 3.days.ago
 + git gc --auto
 Auto packing the repository in background for optimum performance.
 See "git help gc" for manual housekeeping.
 error: The last gc run reported the following. Please correct the root cause
 and remove .git/gc.log.
 Automatic cleanup will not be performed until the file is removed.

 warning: There are too many unreachable loose objects; run 'git prune' to remove them.
```

We can try to run a explicit `git prune` before `git gc`.

I don't have permissions to exec into the prod pod. @ameukam before we merge this PR, can you exec and run these commands for the client-go repo?

```bash
# shows the unreachable objects
$ git fsck --unreachable

# dry-run of the prune command we will run in this PR
$ git prune --dry-run --verbose --progress --expire=3.days.ago
```

/hold

/assign @sttts @ameukam 
[slack thread](https://kubernetes.slack.com/archives/C2C40FMNF/p1652069267337259)