### PR TITLE
Update image for automatic image publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GIT_TAG ?= $(shell git describe --tags --always --dirty)
 
 # Image variables
 IMG_REGISTRY ?= gcr.io/k8s-staging-publishing-bot
-IMG_NAME = publishing-bot
+IMG_NAME = k8s-publishing-bot
 
 IMG_VERSION ?= v0.0.0-1
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,6 +44,6 @@ tags:
 - ${_IMG_VERSION}
 
 images:
-- 'gcr.io/$PROJECT_ID/publishing-bot:$_GIT_TAG'
-- 'gcr.io/$PROJECT_ID/publishing-bot:$_IMG_VERSION'
-- 'gcr.io/$PROJECT_ID/publishing-bot:latest'
+- 'gcr.io/$PROJECT_ID/k8s-publishing-bot:$_GIT_TAG'
+- 'gcr.io/$PROJECT_ID/k8s-publishing-bot:$_IMG_VERSION'
+- 'gcr.io/$PROJECT_ID/k8s-publishing-bot:latest'


### PR DESCRIPTION
The bot uses the `k8s-publishing-bot` image, not the `publishing-bot` image - https://github.com/kubernetes/publishing-bot/blob/master/configs/kubernetes#L1

So we should update the GCB config to match what the bot uses.

/assign @dims 