### PR TITLE
chore: update StorageClass to v1

### DIFF
--- a/artifacts/manifests/storage-class.yaml
+++ b/artifacts/manifests/storage-class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: ssd
 provisioner: kubernetes.io/gce-pd


### PR DESCRIPTION
updating deprecated storage.k8s.io/v1beta1 StorageClass to v1

Signed-off-by: Akhil Mohan <akhilerm@gmail.com>