### PR TITLE
enable owners aliases and update sig release/release-engineer group

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,10 @@
 approvers:
-  #- sig-release-leads # TODO(owners): Enable upon the release of Kubernetes v1.24
-  #- release-engineering-approvers # TODO(owners): Enable upon the release of Kubernetes v1.24
+  - sig-release-leads
+  - release-engineering-approvers
   - dims
   - nikhita
   - sttts
 reviewers:
-  - release-engineering-approvers # TODO(owners): Remove upon the release of Kubernetes v1.24
-  #- release-engineering-reviewers # TODO(owners): Enable upon the release of Kubernetes v1.24
+  - release-engineering-reviewers
 emeritus_approvers:
   - caesarxuchao

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,23 +3,23 @@
 aliases:
   sig-release-leads:
     - cpanato # SIG Technical Lead
-    - jeremyrickard # SIG Technical Lead
+    - jeremyrickard # SIG Chair
     - justaugustus # SIG Chair
     - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
+    - Verolop # SIG Technical Lead
   release-engineering-approvers:
-    - cpanato # Release Manager
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner / Release Manager
     - justaugustus # subproject owner / Release Manager
     - palnabarun # Release Manager
-    - puerco # Release Manager
+    - puerco # subproject owner / Release Manager
     - saschagrunert # subproject owner / Release Manager
-    - Verolop # Release Manager
     - xmudrii # Release Manager
+    - Verolop # subproject owner / Release Manager
   release-engineering-reviewers:
     - ameukam # Release Manager Associate
+    - cici37 # Release Manager Associate
     - jimangel # Release Manager Associate
-    - mkorbi # Release Manager Associate
-    - onlydole # Release Manager Associate
-    - sethmccombs # Release Manager Associate
-    - thejoycekung # Release Manager Associate
-    - wilsonehusin # Release Manager Associate
+    - jrsapi # Release Manager Associate
+    - salaxander # Release Manager Associate


### PR DESCRIPTION
- enable owners aliases and update sig release/release-engineer group
This was supposed to be enabled/cleanup after release 1.24 :)

/assign @justaugustus @saschagrunert @nikhita @dims 