### PR TITLE
go get explicit versions to avoid ambiguous imports

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -831,6 +831,7 @@ update-deps-in-gomod() {
     [ -s go.sum ] && rm go.sum
 
     GO111MODULE=on GOPRIVATE="${dep_packages}" GOPROXY=https://proxy.golang.org go mod download
+    fixAmbiguousImports
     GOPROXY="file://${GOPATH}/pkg/mod/cache/download,https://proxy.golang.org" GO111MODULE=on GOPRIVATE="${dep_packages}" go mod tidy
 
     git add go.mod go.sum
@@ -851,6 +852,13 @@ update-deps-in-gomod() {
 
     # nothing should be left
     ensure-clean-working-dir
+}
+
+function fixAmbiguousImports() {
+   # ref: https://github.com/kubernetes/publishing-bot/issues/304
+   # TODO(nikhita): remove this when k/k drops or bumps
+   # cloud.google.com/go to a version > v0.105.0
+   go get cloud.google.com/go@v0.97.0
 }
 
 gomod-pseudo-version() {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/publishing-bot/issues/304

Ref: https://github.com/kubernetes/kubernetes/issues/113366, https://github.com/kubernetes/kubernetes/pull/114829

I haven't had the chance to do a test run of the bot to verify this but can reproduce this locally using:

1. Clone the https://github.com/kubernetes/kube-aggregator repo (the publishing-bot fails while publishing this repo).
2. Run `go mod edit -require=golang.org/x/oauth2@v0.3.0`. It's not an exact representation of what the bot does since it doesn't update k8s deps but it's enough to reproduce the error.
3. Run `go mod tidy`. We'll see a failure:

```
k8s.io/kube-aggregator/pkg/cmd/server imports
	k8s.io/apiserver/pkg/server/options imports
	k8s.io/apiserver/pkg/storage/storagebackend/factory imports
	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc tested by
	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.test imports
	google.golang.org/grpc/interop imports
	golang.org/x/oauth2/google imports
	cloud.google.com/go/compute/metadata: ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules:
	cloud.google.com/go v0.97.0 (/Users/nraghunath/go/pkg/mod/cloud.google.com/go@v0.97.0/compute/metadata)
	cloud.google.com/go/compute/metadata v0.2.0 (/Users/nraghunath/go/pkg/mod/cloud.google.com/go/compute/metadata@v0.2.0)
```

4. Run `go get cloud.google.com/go@v0.97.0` and then run `go mod tidy` again. It passes without an error.

**Notes**:

1. Even after this change is merged, if someone clones the repo they'll always be a need to run a `go get cloud.google.com/go@v0.97.0` for `go mod tidy` to succeed (due to https://github.com/golang/go/issues/27899).
2. Running a `go get cloud.google.com/go/compute/metadata@v0.2.0` will also technically allow `go mod tidy` for kube-aggregator but it'll fail for apiserver becaue it has an explict require directive for `cloud.google.com/go@v0.97.0`.

This will be necessary until we bump `cloud.google.com/go` or remove dependency on it as mentioned in https://github.com/kubernetes/publishing-bot/issues/304.


/hold
for review

/cc @dims @liggitt 