### PR TITLE
Revert "go get explicit versions to avoid ambiguous imports"

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -831,7 +831,6 @@ update-deps-in-gomod() {
     [ -s go.sum ] && rm go.sum
 
     GO111MODULE=on GOPRIVATE="${dep_packages}" GOPROXY=https://proxy.golang.org go mod download
-    fixAmbiguousImports
     GOPROXY="file://${GOPATH}/pkg/mod/cache/download,https://proxy.golang.org" GO111MODULE=on GOPRIVATE="${dep_packages}" go mod tidy
 
     git add go.mod go.sum
@@ -852,13 +851,6 @@ update-deps-in-gomod() {
 
     # nothing should be left
     ensure-clean-working-dir
-}
-
-function fixAmbiguousImports() {
-   # ref: https://github.com/kubernetes/publishing-bot/issues/304
-   # TODO(nikhita): remove this when k/k drops or bumps
-   # cloud.google.com/go to a version > v0.105.0
-   go get cloud.google.com/go@v0.97.0
 }
 
 gomod-pseudo-version() {


### PR DESCRIPTION
This reverts commit a329b530fc789a826f7d08776eeef14547bb2a19.

xref https://github.com/kubernetes/publishing-bot/pull/305#discussion_r1062414743

Let's probably do a complete nightly run first.