### PR TITLE
enable support for "/" in branch name

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -139,7 +139,8 @@ fi
 LAST_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 LAST_HEAD=$(git rev-parse HEAD)
 EXTRA_ARGS=()
-PUSH_SCRIPT=../push-tags-${REPO}-${DST_BRANCH}.sh
+# the separator is used to handle branches with / in name
+PUSH_SCRIPT=../push-tags-${REPO}-${DST_BRANCH/\//_}.sh
 echo "#!/bin/bash" > ${PUSH_SCRIPT}
 chmod +x ${PUSH_SCRIPT}
 

--- a/artifacts/scripts/push.sh
+++ b/artifacts/scripts/push.sh
@@ -39,4 +39,4 @@ cleanup_github_token() {
 trap cleanup_github_token EXIT SIGINT
 
 HOME=/netrc git push origin "${BRANCH}" --no-tags
-HOME=/netrc ../push-tags-$(basename "${PWD}")-${BRANCH}.sh
+HOME=/netrc ../push-tags-$(basename "${PWD}")-${BRANCH/\//_}.sh

--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -518,8 +518,8 @@ sync_repo() {
 
     # create look-up file for collapsed upstream commits
     local repo=$(basename ${PWD})
-    echo "Writing k8s.io/kubernetes commit lookup table to ../kube-commits-${repo}-${dst_branch}"
-    /collapsed-kube-commit-mapper --commit-message-tag $(echo ${source_repo_name} | sed 's/^./\L\u&/')-commit --source-branch refs/heads/upstream-branch > ../kube-commits-${repo}-${dst_branch}
+    echo "Writing k8s.io/kubernetes commit lookup table to ../kube-commits-${repo}-${dst_branch/\//_}"
+    /collapsed-kube-commit-mapper --commit-message-tag $(echo ${source_repo_name} | sed 's/^./\L\u&/')-commit --source-branch refs/heads/upstream-branch > ../kube-commits-${repo}-${dst_branch/\//_}
 }
 
 # for some PR branches cherry-picks fail. Put commits here where we only pick the whole merge as a single commit.

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -409,7 +409,9 @@ func (p *PublisherMunger) publish(newUpstreamHeads map[string]plumbing.Hash) err
 					path.Dir(dstDir),
 					publishedFileName(repoRules.DestinationRepository, strings.Replace(branchRule.Name, "/", "_", 1)),
 				),
-				[]byte(upstreamBranchHead.String()), 0o644); err != nil {
+				[]byte(upstreamBranchHead.String()),
+				0o644,
+			); err != nil {
 				return err
 			}
 		}

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -404,7 +404,12 @@ func (p *PublisherMunger) publish(newUpstreamHeads map[string]plumbing.Hash) err
 			if !ok {
 				return fmt.Errorf("no upstream branch %q found", branchRule.Source.Branch)
 			}
-			if err := os.WriteFile(path.Join(path.Dir(dstDir), publishedFileName(repoRules.DestinationRepository, branchRule.Name)), []byte(upstreamBranchHead.String()), 0o644); err != nil {
+			if err := os.WriteFile(
+				path.Join(
+					path.Dir(dstDir),
+					publishedFileName(repoRules.DestinationRepository, strings.Replace(branchRule.Name, "/", "_", 1)),
+				),
+				[]byte(upstreamBranchHead.String()), 0o644); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
containerd uses `/` in branch name like `release/1.6`, `release/1.7` etc.  To support this use case, names containing `/` which is a directory separator in linux should be handled separately.

The "/" in destination branch name needs to be treated differently as the branch name is used as suffix in certain file names. Therefore "/" is replaced with "_" wherever the files are created/accessed using the branch name suffix.

Part of #320 