### PR TITLE
add support for configuring default git branch

### DIFF
--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -37,8 +37,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [ ! $# -eq 14 ]; then
-    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name base_package is_library recursive_delete_pattern skip_tags last_published_upstream_hash"
+if [ ! $# -eq 15 ]; then
+    echo "usage: $0 repo src_branch dst_branch dependent_k8s.io_repos required_packages kubernetes_remote subdirectory source_repo_org source_repo_name base_package is_library recursive_delete_pattern skip_tags last_published_upstream_hash git_default_branch"
     exit 1
 fi
 

--- a/artifacts/scripts/construct.sh
+++ b/artifacts/scripts/construct.sh
@@ -74,8 +74,10 @@ RECURSIVE_DELETE_PATTERN="${3}"
 SKIP_TAGS="${4}"
 # last published upstream hash of this branch
 LAST_PUBLISHED_UPSTREAM_HASH="${5}"
+# name of the main branch. master for k8s.io/kubernetes
+GIT_DEFAULT_BRANCH="${6}"
 
-readonly REPO SRC_BRANCH DST_BRANCH DEPS REQUIRED SOURCE_REMOTE SOURCE_REPO_ORG SUBDIR SOURCE_REPO_NAME BASE_PACKAGE IS_LIBRARY RECURSIVE_DELETE_PATTERN SKIP_TAGS LAST_PUBLISHED_UPSTREAM_HASH
+readonly REPO SRC_BRANCH DST_BRANCH DEPS REQUIRED SOURCE_REMOTE SOURCE_REPO_ORG SUBDIR SOURCE_REPO_NAME BASE_PACKAGE IS_LIBRARY RECURSIVE_DELETE_PATTERN SKIP_TAGS LAST_PUBLISHED_UPSTREAM_HASH GIT_DEFAULT_BRANCH
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
@@ -130,7 +132,7 @@ if [ "${UPSTREAM_HASH}" != "${LAST_PUBLISHED_UPSTREAM_HASH}" ]; then
     echo "Upstream branch upstream/${SRC_BRANCH} moved from '${LAST_PUBLISHED_UPSTREAM_HASH}' to '${UPSTREAM_HASH}'. We have to sync."
     # sync_repo cherry-picks the commits that change
     # k8s.io/kubernetes/staging/src/k8s.io/${REPO} to the ${DST_BRANCH}
-    sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${DEPS}" "${REQUIRED}" "${BASE_PACKAGE}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}"
+    sync_repo "${SOURCE_REPO_ORG}" "${SOURCE_REPO_NAME}" "${SUBDIR}" "${SRC_BRANCH}" "${DST_BRANCH}" "${DEPS}" "${REQUIRED}" "${BASE_PACKAGE}" "${IS_LIBRARY}" "${RECURSIVE_DELETE_PATTERN}" "${GIT_DEFAULT_BRANCH}"
 else
     echo "Skipping sync because upstream/${SRC_BRANCH} at ${UPSTREAM_HASH} did not change since last sync."
 fi

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -87,6 +87,11 @@ func main() {
 	if cfg.GithubHost == "" {
 		cfg.GithubHost = "github.com"
 	}
+
+	if cfg.GitDefaultBranch == "" {
+		cfg.GitDefaultBranch = "master"
+	}
+
 	// defaulting when base package is not specified
 	if cfg.BasePackage == "" {
 		if cfg.SourceRepo == "kubernetes" {

--- a/cmd/publishing-bot/config/config.go
+++ b/cmd/publishing-bot/config/config.go
@@ -51,4 +51,7 @@ type Config struct {
 	// BasePublishScriptPath determine the base path where we will look for a
 	// publishing scripts in the source repo. It defaults to ./publishing_scripts'.
 	BasePublishScriptPath string `yaml:"base-publish-script-path,omitempty"`
+
+	// name of the default git branch in the repo. defaults to master
+	GitDefaultBranch string `yaml:"git-default-branch,omitempty"`
 }

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -107,6 +107,10 @@ func main() { //nolint: gocyclo
 		cfg.GithubHost = "github.com"
 	}
 
+	if cfg.GitDefaultBranch == "" {
+		cfg.GitDefaultBranch = "master"
+	}
+
 	var err error
 	cfg.BasePublishScriptPath, err = filepath.Abs(cfg.BasePublishScriptPath)
 	if err != nil {

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -147,11 +147,11 @@ func (p *PublisherMunger) updateSourceRepo() (map[string]plumbing.Hash, error) {
 func (p *PublisherMunger) updateRules() error {
 	repoDir := filepath.Join(p.baseRepoPath, p.config.SourceRepo)
 
-	glog.Infof("Checking out master at %s.", repoDir)
-	cmd := exec.Command("git", "checkout", "master")
+	glog.Infof("Checking out %s at %s.", p.config.GitDefaultBranch, repoDir)
+	cmd := exec.Command("git", "checkout", p.config.GitDefaultBranch)
 	cmd.Dir = repoDir
 	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to checkout master: %v", err)
+		return fmt.Errorf("failed to checkout %s: %v", p.config.GitDefaultBranch, err)
 	}
 
 	rules, err := config.LoadRules(p.config.RulesFile)
@@ -317,6 +317,7 @@ func (p *PublisherMunger) construct() error {
 				strings.Join(p.reposRules.RecursiveDeletePatterns, " "),
 				skipTags,
 				lastPublishedUpstreamHash,
+				p.config.GitDefaultBranch,
 			)
 			cmd.Env = append([]string(nil), branchEnv...) // make mutable
 			if p.reposRules.SkipGomod {

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
-const MainBranchName = "master"
+const GitDefaultBranch = "master"
 
 type options struct {
 	branch    string
@@ -128,7 +128,7 @@ func UpdateRules(rules *config.RepositoryRules, branch, goVer string) {
 		var newBranchRule config.BranchRule
 		// find the mainBranch rules
 		for _, br := range r.Branches {
-			if br.Name == MainBranchName {
+			if br.Name == GitDefaultBranch {
 				cloneBranchRule(&br, &newBranchRule)
 				mainBranchRuleFound = true
 				break
@@ -137,7 +137,7 @@ func UpdateRules(rules *config.RepositoryRules, branch, goVer string) {
 
 		// if mainBranch rules not found for repo, it means it's removed from master tree, log warning and skip updating the rules
 		if !mainBranchRuleFound {
-			glog.Warningf("%s branch rules not found for repo %s, skipping to update branch %s rules", MainBranchName, r.DestinationRepository, branch)
+			glog.Warningf("%s branch rules not found for repo %s, skipping to update branch %s rules", GitDefaultBranch, r.DestinationRepository, branch)
 			continue
 		}
 


### PR DESCRIPTION
currently only master branch is supported as the default branch. This change adds a new `git-default-branch` in the config that can be used to set the default branch to be used while running `publishing-bot` and `init-repo` commands

Part of #320 