### PR TITLE
Switched from N1 to E2 machine

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
   # TODO(image): Consider a smaller machine type
-  machineType: N1_HIGHCPU_32
+  machineType: E2_HIGHCPU_32
 
 steps:
 - name: 'gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default'


### PR DESCRIPTION
Reference https://github.com/kubernetes/k8s.io/issues/5059

This changes machine type from N1 to E2 which are newer but almost same pricing. But with E2 being more efficient and overall taking less time. The cost can be reduced.