### PR TITLE
update golangci-lint to v1.53.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - "area/dependency"
       - "release-note-none"
+      - "ok-to-test"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
@@ -16,4 +17,5 @@ updates:
     labels:
       - "area/dependency"
       - "release-note-none"
+      - "ok-to-test"
     open-pull-requests-limit: 10

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
-          version: v1.51.2
+          version: v1.53

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -216,9 +216,9 @@ func main() { //nolint: gocyclo
 			if publisherErr != nil {
 				if exitErr, ok := publisherErr.(*exec.ExitError); ok {
 					os.Exit(exitErr.ExitCode())
-				} else {
-					os.Exit(1)
 				}
+
+				os.Exit(1)
 			}
 			break
 		}

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -80,7 +80,7 @@ func (h *Server) Run(port int) error { //nolint: unparam
 	return nil
 }
 
-func (h *Server) runHandler(w http.ResponseWriter, r *http.Request) {
+func (h *Server) runHandler(w http.ResponseWriter, _ *http.Request) {
 	if h.RunChan == nil {
 		http.Error(w, "run channel is closed", http.StatusInternalServerError)
 		return
@@ -94,7 +94,7 @@ func (h *Server) runHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("OK")) //nolint: errcheck
 }
 
-func (h *Server) healthzHandler(w http.ResponseWriter, r *http.Request) {
+func (h *Server) healthzHandler(w http.ResponseWriter, _ *http.Request) {
 	h.mutex.RLock()
 	resp := h.response
 	if h.Issue != 0 {

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.51.2
+VERSION=v1.53.3
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -102,9 +102,6 @@ func installGoVersion(v, pth string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("command %q failed: %v", strings.Join(cmd.Args, " "), err)
 	}
-	if err := os.Rename(tmpPath, pth); err != nil {
-		return err
-	}
 
-	return nil
+	return os.Rename(tmpPath, pth)
 }


### PR DESCRIPTION
- enable ok to test for dependabot prs
- update golangci-lint to v1.53.x
- fix lints

/assign @saschagrunert @ameukam  @palnabarun 
cc @kubernetes/release-managers 