### PR TITLE
Fix fractional value memory limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ INTERVAL ?= 86400
 CPU_LIMITS ?= 2
 CPU_REQUESTS ?= 300m
 MEMORY_REQUESTS ?= 200Mi
-MEMORY_LIMITS ?= 1.6Gi
+MEMORY_LIMITS ?= 1639Mi
 GOOS ?= linux
 
 build_cmd = GO111MODULE=on mkdir -p _output && GOOS=$(GOOS) go build -o _output/$(1) ./cmd/$(1)

--- a/artifacts/manifests/podspec.yaml
+++ b/artifacts/manifests/podspec.yaml
@@ -14,7 +14,7 @@ initContainers:
       memory: 200Mi
     limits:
       cpu: 2
-      memory: 1.6Gi
+      memory: 1639Mi
   volumeMounts:
   - mountPath: /etc/munge-config
     name: munge-config


### PR DESCRIPTION
Fixes #365 

This PR will change the memory limit from 1.6Gi to 1639Mi(_ceiling of `1638.4Mi`_) which does not represent a floating value.
1.6Gi = 1638.4 Mi = 1,677,721.6 Ki
1.5Gi = 1536 Mi = 1,572,864 Ki