### PR TITLE
set CGO_ENABLED=0 for compiling publishing-bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ MEMORY_REQUESTS ?= 200Mi
 MEMORY_LIMITS ?= 1639Mi
 GOOS ?= linux
 
-build_cmd = GO111MODULE=on mkdir -p _output && GOOS=$(GOOS) go build -o _output/$(1) ./cmd/$(1)
+build_cmd = mkdir -p _output && GOOS=$(GOOS) CGO_ENABLED=0 go build -o _output/$(1) ./cmd/$(1)
 prepare_spec = sed 's,DOCKER_IMAGE,$(DOCKER_REPO),g;s,CPU_LIMITS,$(CPU_LIMITS),g;s,CPU_REQUESTS,$(CPU_REQUESTS),g;s,MEMORY_REQUESTS,$(MEMORY_REQUESTS),g;s,MEMORY_LIMITS,$(MEMORY_LIMITS),g'
 
 SHELL := /bin/bash


### PR DESCRIPTION
set CGO_ENABLED=0, so that static binaries are generated for the various publishing-bot components. This is needed because, when the build image `gcr.io/k8s-staging-releng/k8s-ci-builder:latest-default` was upgraded from bullseye to bookworm (kubernetes/release#3212), glibc version incompatibility occurred between the build machine and the prod cluster, preventing the bot from starting up.