### PR TITLE
Bump debian and git version for publishing-bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:bullseye
+FROM debian:bookworm
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.30.2-1+deb11u2 \
+ && apt-get install -y -qq git=1:2.39.2-1.1 \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GIT_TAG ?= $(shell git describe --tags --always --dirty)
 IMG_REGISTRY ?= gcr.io/k8s-staging-publishing-bot
 IMG_NAME = k8s-publishing-bot
 
-IMG_VERSION ?= v0.0.0-1
+IMG_VERSION ?= v0.0.0-2
 
 # TODO(image): Consider renaming this variable
 DOCKER_REPO ?= $(IMG_REGISTRY)/$(IMG_NAME)


### PR DESCRIPTION
Let's try a fresh version of `git` to see if this gets past the problem with broken publishing-bot runs