### PR TITLE
Update golangci-lint to v1.55.2 and fix gocritic

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.53
+          version: v1.55

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,77 +101,112 @@ linters-settings:
     check-blank: true
   gocritic:
     enabled-checks:
-      # Diagnostic
       - appendAssign
+      - appendCombine
       - argOrder
+      - assignOp
+      - badCall
       - badCond
+      - badLock
+      - badRegexp
+      - badSorting
+      - boolExprSimplify
+      - builtinShadow
+      - builtinShadowDecl
+      - captLocal
       - caseOrder
       - codegenComment
+      - commentFormatting
       - commentedOutCode
+      - commentedOutImport
+      - defaultCaseOrder
+      - deferInLoop
+      - deferUnlambda
       - deprecatedComment
+      - docStub
       - dupArg
       - dupBranchBody
       - dupCase
+      - dupImport
       - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - offBy1
-      - sloppyReassign
-      - weakCond
-      # TODO(lint): Temporarily disabled for compat with older Golang versions
-      #- octalLiteral
-
-      # Performance
-      - appendCombine
-      - equalFold
-      # TODO(lint): Temporarily disabled to prevent pointer handling issues
-      #- hugeParam
-      - indexAlloc
-      - rangeExprCopy
-      # TODO(lint): Temporarily disabled to prevent pointer handling issues
-      #- rangeValCopy
-
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
+      - dynamicFmtString
       - elseif
+      - emptyDecl
       - emptyFallthrough
       - emptyStringTest
+      - equalFold
+      - evalOrder
+      - exitAfterDefer
+      - exposedSyncMutex
+      - externalErrorReassign
+      - filepathJoin
+      - flagDeref
+      - flagName
       - hexLiteral
+      - httpNoBody
+      - hugeParam
+      - ifElseChain
+      - importShadow
+      - indexAlloc
+      - initClause
+      - mapKey
       - methodExprCall
+      - nestingReduce
+      - newDeref
+      - nilValReturn
+      - octalLiteral
+      - offBy1
+      - paramTypeCombine
+      - preferDecodeRune
+      - preferFilepathJoin
+      - preferFprint
+      - preferStringWriter
+      - preferWriteByte
+      - ptrToRefParam
+      - rangeExprCopy
+      - rangeValCopy
+      - redundantSprint
       - regexpMust
+      - regexpPattern
+      - regexpSimplify
+      - returnAfterHttpError
+      - ruleguard
       - singleCaseSwitch
+      - sliceClear
       - sloppyLen
+      - sloppyReassign
+      - sloppyTestFuncName
+      - sloppyTypeAssert
+      - sortSlice
+      - sprintfQuotedString
+      - sqlQuery
+      - stringConcatSimplify
       - stringXbytes
+      - stringsCompare
       - switchTrue
+      - syncMapLoadAndDelete
+      - timeCmpSimplify
+      - timeExprSimplify
+      - todoCommentWithoutDetail
+      - tooManyResultsChecker
+      - truncateCmp
       - typeAssertChain
+      - typeDefFirst
       - typeSwitchVar
+      - typeUnparen
+      - uncheckedInlineErr
       - underef
       - unlabelStmt
       - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      - yodaStyleExpr
-      # - ifElseChain
-
-      # Opinionated
-      - builtinShadow
-      - importShadow
-      - initClause
-      - nestingReduce
-      - paramTypeCombine
-      - ptrToRefParam
-      - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+      - unnecessaryDefer
+      - unslice
+      - valSwap
+      - weakCond
+      - whyNoLint
+      - wrapperFunc
+      - yodaStyleExpr
   nolintlint:
     # Enable to ensure that nolint directives are all used. Default is true.
     allow-unused: false

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.Usage = Usage
 	flag.Parse()
 
-	cfg := config.Config{}
+	cfg := &config.Config{}
 	if *configFilePath != "" {
 		bs, err := os.ReadFile(*configFilePath)
 		if err != nil {
@@ -141,7 +141,7 @@ func main() {
 	}
 }
 
-func cloneForkRepo(cfg config.Config, repoName string) {
+func cloneForkRepo(cfg *config.Config, repoName string) {
 	forkRepoLocation := fmt.Sprintf("https://%s/%s/%s", cfg.GithubHost, cfg.TargetOrg, repoName)
 	repoDir := filepath.Join(BaseRepoPath, repoName)
 
@@ -178,7 +178,7 @@ func run(c *exec.Cmd) {
 	}
 }
 
-func cloneSourceRepo(cfg config.Config) {
+func cloneSourceRepo(cfg *config.Config) {
 	repoLocation := fmt.Sprintf("https://%s/%s/%s", cfg.GithubHost, cfg.SourceOrg, cfg.SourceRepo)
 
 	if _, err := os.Stat(filepath.Join(BaseRepoPath, cfg.SourceRepo)); err == nil {

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -125,7 +125,7 @@ func readFromURL(u *url.URL) ([]byte, error) {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", u.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,8 @@ func validateRepoOrder(rules *RepositoryRules) (errs []error) {
 	}
 
 	for i, r := range rules.Rules {
-		for _, br := range r.Branches {
+		for bri := range r.Branches {
+			br := r.Branches[bri]
 			for _, d := range br.Dependencies {
 				if j, ok := indices[d.Repository]; !ok {
 					errs = append(errs, fmt.Errorf("unknown dependency %q in repository rules of %q", d.Repository, r.DestinationRepository))
@@ -168,8 +169,10 @@ func validateGoVersions(rules *RepositoryRules) (errs []error) {
 		errs = append(errs, ensureValidGoVersion(*rules.DefaultGoVersion))
 	}
 
-	for _, rule := range rules.Rules {
-		for _, branch := range rule.Branches {
+	for i := range rules.Rules {
+		rule := rules.Rules[i]
+		for j := range rule.Branches {
+			branch := rule.Branches[j]
 			if branch.GoVersion != "" {
 				errs = append(errs, ensureValidGoVersion(branch.GoVersion))
 			}
@@ -243,7 +246,8 @@ func ensureValidGoVersion(version string) error {
 // this makes sure that old dir field values are copied over to new dirs field
 func fixDeprecatedFields(rules *RepositoryRules) {
 	for i, rule := range rules.Rules {
-		for j, branch := range rule.Branches {
+		for j := range rule.Branches {
+			branch := rule.Branches[j]
 			if len(branch.Source.Dirs) == 0 && branch.Source.Dir != "" {
 				rules.Rules[i].Branches[j].Source.Dirs = append(rules.Rules[i].Branches[j].Source.Dirs, branch.Source.Dir)
 				// The Dir field is made empty so that it is not used later and only the Dirs

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -42,8 +42,8 @@ Command line flags override config values.
 	flag.PrintDefaults()
 }
 
-// TODO(lint): cyclomatic complexity 38 of func `main` is high (> 30)
-func main() { //nolint: gocyclo
+//nolint:gocyclo  // TODO(lint): cyclomatic complexity 38 of func `main` is high (> 30)
+func main() {
 	configFilePath := flag.String("config", "", "the config file in yaml format")
 	githubHost := flag.String("github-host", "", "the address of github (defaults to github.com)")
 	basePackage := flag.String("base-package", "", "the name of the package base (defaults to k8s.io when source repo is kubernetes, "+
@@ -155,9 +155,7 @@ func main() { //nolint: gocyclo
 		RunChan: runChan,
 	}
 	if *serverPort != 0 {
-		if err := server.Run(*serverPort); err != nil {
-			glog.Fatalf("Failed to run healthz server: %v", err)
-		}
+		server.Run(*serverPort)
 	}
 
 	githubIssueErrorf := glog.Fatalf
@@ -202,7 +200,7 @@ func main() { //nolint: gocyclo
 			}
 		} else {
 			// run
-			if _, _, publisherErr = publisher.Run(); err != nil {
+			if _, _, publisherErr = publisher.Run(); publisherErr != nil {
 				glog.Infof("Failed to run publisher: %v", publisherErr)
 			}
 		}

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -263,7 +263,8 @@ func (p *PublisherMunger) construct() error {
 		}
 
 		// construct branches
-		for _, branchRule := range repoRule.Branches {
+		for i := range repoRule.Branches {
+			branchRule := repoRule.Branches[i]
 			if p.skippedBranch(branchRule.Source.Branch) {
 				continue
 			}
@@ -272,8 +273,8 @@ func (p *PublisherMunger) construct() error {
 				p.plog.Infof("%v: 'dir' cannot be empty, defaulting to '.'", branchRule)
 			}
 
-			// get old HEAD. Ignore errors as the branch might be non-existent
-			oldHead, _ := exec.Command("git", "rev-parse", fmt.Sprintf("origin/%s", branchRule.Name)).Output() //nolint: errcheck
+			//nolint:errcheck // get old HEAD. Ignore errors as the branch might be non-existent
+			oldHead, _ := exec.Command("git", "rev-parse", fmt.Sprintf("origin/%s", branchRule.Name)).Output()
 
 			goPath := os.Getenv("GOPATH")
 			branchEnv := append([]string(nil), os.Environ()...) // make mutable
@@ -327,8 +328,8 @@ func (p *PublisherMunger) construct() error {
 				return err
 			}
 
-			// TODO(lint): Should we be checking errors here?
-			newHead, _ := exec.Command("git", "rev-parse", "HEAD").Output() //nolint: errcheck
+			//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+			newHead, _ := exec.Command("git", "rev-parse", "HEAD").Output()
 
 			p.plog.Infof("Running branch-specific smoke tests for branch %s", branchRule.Name)
 			if err := p.runSmokeTests(branchRule.SmokeTest, string(oldHead), string(newHead), branchEnv); err != nil {
@@ -391,7 +392,8 @@ func (p *PublisherMunger) publish(newUpstreamHeads map[string]plumbing.Hash) err
 		}
 
 		p.plog.Infof("Pushing branches for %s", repoRules.DestinationRepository)
-		for _, branchRule := range repoRules.Branches {
+		for i := range repoRules.Branches {
+			branchRule := repoRules.Branches[i]
 			if p.skippedBranch(branchRule.Source.Branch) {
 				continue
 			}

--- a/cmd/publishing-bot/publisher_logger.go
+++ b/cmd/publishing-bot/publisher_logger.go
@@ -53,14 +53,14 @@ func newPublisherLog(buf *bytes.Buffer, logFileName string) (*plog, error) {
 }
 
 func (p *plog) write(s string) {
-	// TODO(lint): Should we be checking errors here?
-	p.combinedBufAndFile.Write([]byte("[" + time.Now().Format(time.RFC822) + "]: ")) //nolint: errcheck
+	//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+	p.combinedBufAndFile.Write([]byte("[" + time.Now().Format(time.RFC822) + "]: "))
 
-	// TODO(lint): Should we be checking errors here?
-	p.combinedBufAndFile.Write([]byte(s)) //nolint: errcheck
+	//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+	p.combinedBufAndFile.Write([]byte(s))
 
-	// TODO(lint): Should we be checking errors here?
-	p.combinedBufAndFile.Write([]byte("\n")) //nolint: errcheck
+	//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+	p.combinedBufAndFile.Write([]byte("\n"))
 }
 
 func (p *plog) Errorf(format string, args ...interface{}) {
@@ -82,7 +82,7 @@ func (p *plog) Fatalf(format string, args ...interface{}) {
 }
 
 func (p *plog) Run(c *exec.Cmd) error {
-	p.Infof("%s", cmdStr(*c))
+	p.Infof("%s", cmdStr(c))
 
 	errBuf := &bytes.Buffer{}
 
@@ -123,9 +123,7 @@ func prefixFollowingLines(p, s string) string {
 	return strings.Join(lines, "\n")
 }
 
-type cmdStr exec.Cmd
-
-func (cs cmdStr) String() string {
+func cmdStr(cs *exec.Cmd) string {
 	args := make([]string, len(cs.Args))
 	for i, s := range cs.Args {
 		if strings.ContainsRune(s, ' ') {
@@ -178,8 +176,8 @@ func (lw lineWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
-// TODO(lint): result 0 (int) is never used
-func (lw lineWriter) Flush() (int, error) { //nolint: unparam
+//nolint:unparam  // TODO(lint): result 0 (int) is never used
+func (lw lineWriter) Flush() (int, error) {
 	written, err := lw.buf.WriteTo(lw.writer)
 	lw.buf.Reset()
 	return int(written), err

--- a/cmd/publishing-bot/publisher_logger_test.go
+++ b/cmd/publishing-bot/publisher_logger_test.go
@@ -43,8 +43,8 @@ func TestLogLineWriter(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			for i := 0; i < 99999; i++ {
-				// TODO(lint): Should we be checking errors here?
-				w.Write([]byte(content + "\n")) //nolint: errcheck
+				//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+				w.Write([]byte(content + "\n"))
 			}
 			wg.Done()
 		}()

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -66,8 +66,7 @@ func (h *Server) SetHealth(healthy bool, hash string) {
 	}
 }
 
-// TODO(lint): result 0 (error) is always nil
-func (h *Server) Run(port int) error { //nolint: unparam
+func (h *Server) Run(port int) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthzHandler)
 	mux.HandleFunc("/run", h.runHandler)
@@ -77,7 +76,6 @@ func (h *Server) Run(port int) error { //nolint: unparam
 		err := http.ListenAndServe(addr, mux)
 		glog.Fatalf("Failed ListenAndServer: %v", err)
 	}()
-	return nil
 }
 
 func (h *Server) runHandler(w http.ResponseWriter, _ *http.Request) {
@@ -90,8 +88,8 @@ func (h *Server) runHandler(w http.ResponseWriter, _ *http.Request) {
 	default:
 	}
 
-	// TODO(lint): Should we be checking errors here?
-	w.Write([]byte("OK")) //nolint: errcheck
+	//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+	w.Write([]byte("OK"))
 }
 
 func (h *Server) healthzHandler(w http.ResponseWriter, _ *http.Request) {
@@ -110,6 +108,6 @@ func (h *Server) healthzHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	// TODO(lint): Should we be checking errors here?
-	w.Write(bytes) //nolint: errcheck
+	//nolint:errcheck  // TODO(lint): Should we be checking errors here?
+	w.Write(bytes)
 }

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -205,7 +205,7 @@ func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag string, 
 	}
 	defer listFile.Close()
 
-	if _, err := listFile.WriteString(fmt.Sprintf("%s\n", pseudoVersionOrTag)); err != nil {
+	if _, err := fmt.Fprintf(listFile, "%s\n", pseudoVersionOrTag); err != nil {
 		return fmt.Errorf("unable to write to list file in %s: %v", cacheDir, err)
 	}
 

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -127,7 +127,8 @@ func UpdateRules(rules *config.RepositoryRules, branch, goVer string) {
 		var mainBranchRuleFound bool
 		var newBranchRule config.BranchRule
 		// find the mainBranch rules
-		for _, br := range r.Branches {
+		for i := range r.Branches {
+			br := r.Branches[i]
 			if br.Name == GitDefaultBranch {
 				cloneBranchRule(&br, &newBranchRule)
 				mainBranchRuleFound = true
@@ -146,7 +147,8 @@ func UpdateRules(rules *config.RepositoryRules, branch, goVer string) {
 
 		var branchRuleExists bool
 		// if the target branch rules already exists, update it
-		for i, br := range r.Branches {
+		for i := range r.Branches {
+			br := r.Branches[i]
 			if br.Name == branch {
 				glog.Infof("found branch %s rules for destination repo %s, updating it", branch, r.DestinationRepository)
 				r.Branches[i] = newBranchRule

--- a/cmd/validate-rules/staging/validate.go
+++ b/cmd/validate-rules/staging/validate.go
@@ -38,7 +38,8 @@ func EnsureStagingDirectoriesExist(rules *config.RepositoryRules) []error {
 
 	var errors []error
 	for _, rule := range rules.Rules {
-		for _, branchRule := range rule.Branches {
+		for i := range rule.Branches {
+			branchRule := rule.Branches[i]
 			// ensure all the mentioned directories exist
 			for _, dir := range branchRule.Source.Dirs {
 				_, directory := filepath.Split(dir)

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.53.3
+VERSION=v1.55.2
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -48,7 +48,8 @@ func InstallGoVersions(rules *config.RepositoryRules) error {
 
 	goVersions := []string{defaultGoVersion}
 	for _, rule := range rules.Rules {
-		for _, branch := range rule.Branches {
+		for i := range rule.Branches {
+			branch := rule.Branches[i]
 			if branch.GoVersion != "" {
 				found := false
 				for _, v := range goVersions {


### PR DESCRIPTION
Updating the linter to the latest release, enabling all gocritic linters and fixing them.

