### PR TITLE
Enable more linters and update config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,15 +19,33 @@ issues:
 linters:
   disable-all: true
   enable:
+    - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
     - dogsled
     - dupl
+    - dupword
     - durationcheck
     - errcheck
+    - errchkjson
+    - errname
+    - execinquery
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gochecksumtype
     - goconst
     - gocritic
     - gocyclo
+    - godot
     - godox
     - gofmt
     - gofumpt
@@ -36,58 +54,72 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    # TODO(lint): Enable after fixing other lint warnings
-    #- gosec
     - gosimple
+    - gosmopolitan
     - govet
+    - grouper
     - importas
+    - inamedparam
     - ineffassign
+    - interfacebloat
+    - ireturn
+    - loggercheck
     - makezero
+    - mirror
     - misspell
+    - musttag
     - nakedret
+    - nilerr
     - nolintlint
+    - nosprintfhostport
+    - perfsprint
     - prealloc
     - predeclared
     - promlinter
+    - protogetter
+    - reassign
     - revive
-    # disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
-    # - rowserrcheck
-    # - sqlclosecheck
+    - rowserrcheck
+    - sloglint
+    - sqlclosecheck
     - staticcheck
     - stylecheck
+    - tagalign
+    - tenv
+    - testableexamples
+    - testifylint
+    - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    - wastedassign
     - whitespace
+    - zerologlint
     # - cyclop
+    # - depguard
     # - errorlint
-    # - exhaustive
-    # - exhaustivestruct
-    # - exportloopref
+    # - exhaustruct
     # - forbidigo
-    # - forcetypeassert
     # - funlen
-    # - gci
     # - gochecknoglobals
-    # - gochecknoinits
     # - gocognit
-    # - godot
     # - goerr113
     # - gomnd
-    # - ifshort
+    # - gosec
     # - lll
+    # - maintidx
     # - nestif
-    # - nilerr
+    # - nilnil
     # - nlreturn
     # - noctx
+    # - nonamedreturns
     # - paralleltest
-    # - scopelint
     # - tagliatelle
     # - testpackage
-    # - thelper
-    # - tparallel
-    # - wastedassign
+    # - varnamelen
     # - wrapcheck
     # - wsl
 linters-settings:

--- a/cmd/collapsed-kube-commit-mapper/main.go
+++ b/cmd/collapsed-kube-commit-mapper/main.go
@@ -26,7 +26,6 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/pkg/cache"
 	"k8s.io/publishing-bot/pkg/git"
 )

--- a/cmd/init-repo/main.go
+++ b/cmd/init-repo/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/glog"
 	yaml "gopkg.in/yaml.v2"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -17,7 +17,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// Dependency of a piece of code
+// Dependency of a piece of code.
 type Dependency struct {
 	Repository string `yaml:"repository"`
 	Branch     string `yaml:"branch"`
@@ -31,7 +31,7 @@ func (c Dependency) String() string {
 	return fmt.Sprintf("[repository %s, branch %s]", repo, c.Branch)
 }
 
-// Source of a piece of code
+// Source of a piece of code.
 type Source struct {
 	Repository string `yaml:"repository,omitempty"`
 	Branch     string `yaml:"branch"`
@@ -68,7 +68,7 @@ type BranchRule struct {
 	SmokeTest string `yaml:"smoke-test,omitempty"` // a multiline bash script
 }
 
-// a collection of publishing rules for a single destination repo
+// a collection of publishing rules for a single destination repo.
 type RepositoryRule struct {
 	DestinationRepository string       `yaml:"destination"`
 	Branches              []BranchRule `yaml:"branches"`
@@ -125,7 +125,7 @@ func readFromURL(u *url.URL) ([]byte, error) {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-	req, err := http.NewRequest("GET", u.String(), http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func validateGoVersions(rules *RepositoryRules) (errs []error) {
 // care about). For Go *language versions* >= 1.21, the following are the rules for versions
 // in the go tool chain name:
 // 1. 1.21 is invalid, and 1.21.0 is valid
-// 2. 1.21rc1 and 1.21.0rc1 are valid
+// 2. 1.21rc1 and 1.21.0rc1 are valid.
 var goVerRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?(?:(?P<pre>alpha|beta|rc)\d+)?$`)
 
 func ensureValidGoVersion(version string) error {
@@ -243,7 +243,7 @@ func ensureValidGoVersion(version string) error {
 	return nil
 }
 
-// this makes sure that old dir field values are copied over to new dirs field
+// this makes sure that old dir field values are copied over to new dirs field.
 func fixDeprecatedFields(rules *RepositoryRules) {
 	for i, rule := range rules.Rules {
 		for j := range rule.Branches {

--- a/cmd/publishing-bot/github_test.go
+++ b/cmd/publishing-bot/github_test.go
@@ -18,6 +18,7 @@ package main
 import "testing"
 
 func TestGithubLogTransform(t *testing.T) {
+	//nolint:dupword // this is intentional for the test
 	originLog := `111111111111
 222222
 + hello
@@ -30,6 +31,7 @@ holla bar
 hi foo
 hi bar
 `
+	//nolint:dupword // this is intentional for the test
 	expected := "```" + `
 + hello
 hello foo

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -23,12 +23,12 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 	"k8s.io/publishing-bot/pkg/golang"
 )
@@ -143,7 +143,7 @@ func (p *PublisherMunger) updateSourceRepo() (map[string]plumbing.Hash, error) {
 	return heads, nil
 }
 
-// update the active rules
+// update the active rules.
 func (p *PublisherMunger) updateRules() error {
 	repoDir := filepath.Join(p.baseRepoPath, p.config.SourceRepo)
 
@@ -314,7 +314,7 @@ func (p *PublisherMunger) construct() error {
 				p.config.SourceRepo,
 				p.config.SourceRepo,
 				p.config.BasePackage,
-				fmt.Sprintf("%v", repoRule.Library),
+				strconv.FormatBool(repoRule.Library),
 				strings.Join(p.reposRules.RecursiveDeletePatterns, " "),
 				skipTags,
 				lastPublishedUpstreamHash,

--- a/cmd/publishing-bot/server.go
+++ b/cmd/publishing-bot/server.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 

--- a/cmd/sync-tags/gomod.go
+++ b/cmd/sync-tags/gomod.go
@@ -118,7 +118,7 @@ func updateGomodWithTaggedDependencies(tag string, depsRepo []string, semverTag 
 }
 
 // depImportPaths returns a comma separated string with each dependencies' import path.
-// Eg. "k8s.io/api,k8s.io/apimachinery,k8s.io/client-go"
+// Eg. "k8s.io/api,k8s.io/apimachinery,k8s.io/client-go".
 func depsImportPaths(depsRepo []string) (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -135,10 +135,10 @@ func depsImportPaths(depsRepo []string) (string, error) {
 }
 
 type ModuleInfo struct {
-	Version string
-	Name    string
-	Short   string
-	Time    string
+	Version string `json:"Version,omitempty"`
+	Name    string `json:"Name,omitempty"`
+	Short   string `json:"Short,omitempty"`
+	Time    string `json:"Time,omitempty"`
 }
 
 func packageDepToGoModCache(depPath, depPkg, commit, pseudoVersionOrTag string, commitTime time.Time) error {

--- a/cmd/sync-tags/main.go
+++ b/cmd/sync-tags/main.go
@@ -35,7 +35,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/sideband"
 	"github.com/golang/glog"
 	"github.com/lithammer/dedent"
-
 	"k8s.io/publishing-bot/pkg/cache"
 	"k8s.io/publishing-bot/pkg/git"
 )

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
@@ -108,7 +107,7 @@ func main() {
 	}
 }
 
-// load reads the input rules file and validates the rules
+// load reads the input rules file and validates the rules.
 func load(rulesFile string) (*config.RepositoryRules, error) {
 	rules, err := config.LoadRules(rulesFile)
 	if err != nil {

--- a/cmd/validate-rules/main.go
+++ b/cmd/validate-rules/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 	"k8s.io/publishing-bot/cmd/validate-rules/staging"
 )

--- a/cmd/validate-rules/staging/github_utils.go
+++ b/cmd/validate-rules/staging/github_utils.go
@@ -31,7 +31,7 @@ type File struct {
 }
 
 // fetchKubernetesStagingDirectoryFiles uses the GH API to get the contents
-// of the contents/staging/src/k8s.io directory in a specified branch of kubernetes
+// of the contents/staging/src/k8s.io directory in a specified branch of kubernetes.
 func fetchKubernetesStagingDirectoryFiles(branch string) ([]File, error) {
 	url := "https://api.github.com/repos/kubernetes/kubernetes/contents/staging/src/k8s.io?ref=" + branch
 

--- a/cmd/validate-rules/staging/validate.go
+++ b/cmd/validate-rules/staging/validate.go
@@ -21,18 +21,17 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 
 // globalMapBranchDirectories is a cache to avoid hitting GH limits
 // key is the branch (`master` or `release-1.23`) and the value
 // is the list of files/directories fetched using GH api in the
-// correct directory
+// correct directory.
 var globalMapBranchDirectories = make(map[string][]File)
 
 // EnsureStagingDirectoriesExist walks through the repository rules and checks
-// if the specified directories are present in the specific kubernetes branch
+// if the specified directories are present in the specific kubernetes branch.
 func EnsureStagingDirectoriesExist(rules *config.RepositoryRules) []error {
 	glog.Infof("validating directories exist in the kubernetes branch")
 

--- a/pkg/git/kube.go
+++ b/pkg/git/kube.go
@@ -26,7 +26,7 @@ import (
 // SourceHash extracts kube commit from commit message
 // The baseRepoName default to "kubernetes".
 // TODO: Refactor so we take the commitMsgTag as argument and don't need to
-// construct the ancientSyncCommitSubjectPrefix or sourceCommitPrefix
+// construct the ancientSyncCommitSubjectPrefix or sourceCommitPrefix.
 func SourceHash(c *object.Commit, tag string) plumbing.Hash {
 	lines := strings.Split(c.Message, "\n")
 	sourceCommitPrefix := tag + ": "

--- a/pkg/git/mainline.go
+++ b/pkg/git/mainline.go
@@ -22,7 +22,6 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-
 	"k8s.io/publishing-bot/pkg/cache"
 )
 

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 )
 


### PR DESCRIPTION
Enable more linters which do not report anything as well as update the configuration for them. Additionally enable linters which only report trivial fixes and fix them.

cc @kubernetes/release-engineering 