### PR TITLE
Use wrapped errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,9 @@ issues:
         - gocritic
         - golint
         - dupl
+    - linters:
+        - goerr113
+      text: do not define dynamic errors
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
@@ -33,6 +36,7 @@ linters:
     - errcheck
     - errchkjson
     - errname
+    - errorlint
     - execinquery
     - exhaustive
     - exportloopref
@@ -47,6 +51,7 @@ linters:
     - gocyclo
     - godot
     - godox
+    - goerr113
     - gofmt
     - gofumpt
     - goheader
@@ -70,6 +75,7 @@ linters:
     - musttag
     - nakedret
     - nilerr
+    - noctx
     - nolintlint
     - nosprintfhostport
     - perfsprint
@@ -100,13 +106,11 @@ linters:
     - zerologlint
     # - cyclop
     # - depguard
-    # - errorlint
     # - exhaustruct
     # - forbidigo
     # - funlen
     # - gochecknoglobals
     # - gocognit
-    # - goerr113
     # - gomnd
     # - gosec
     # - lll
@@ -114,7 +118,6 @@ linters:
     # - nestif
     # - nilnil
     # - nlreturn
-    # - noctx
     # - nonamedreturns
     # - paralleltest
     # - tagliatelle

--- a/cmd/gomod-zip/zip.go
+++ b/cmd/gomod-zip/zip.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -78,22 +79,22 @@ func getModuleFile(packagePath, version string) (*modfile.File, error) {
 	goModPath := filepath.Join(packagePath, "go.mod")
 	file, err := os.Open(goModPath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening %s: %v", goModPath, err)
+		return nil, fmt.Errorf("error opening %s: %w", goModPath, err)
 	}
 	defer file.Close()
 
 	moduleBytes, err := io.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %v", goModPath, err)
+		return nil, fmt.Errorf("error reading %s: %w", goModPath, err)
 	}
 
 	moduleFile, err := modfile.Parse(packagePath, moduleBytes, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing module file: %v", err)
+		return nil, fmt.Errorf("error parsing module file: %w", err)
 	}
 
 	if moduleFile.Module == nil {
-		return nil, fmt.Errorf("parsed module should not be nil")
+		return nil, errors.New("parsed module should not be nil")
 	}
 
 	moduleFile.Module.Mod.Version = version

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -209,16 +210,16 @@ func ensureValidGoVersion(version string) error {
 
 	majorVersion, err := strconv.Atoi(match[1])
 	if err != nil {
-		return fmt.Errorf("error parsing major version '%s' : %s", match[1], err)
+		return fmt.Errorf("error parsing major version '%s': %w", match[1], err)
 	}
 	minorVersion, err = strconv.Atoi(match[2])
 	if err != nil {
-		return fmt.Errorf("error parsing minor version '%s' : %s", match[2], err)
+		return fmt.Errorf("error parsing minor version '%s': %w", match[2], err)
 	}
 	if match[3] != "" {
 		patchVersion, err = strconv.Atoi(match[3])
 		if err != nil {
-			return fmt.Errorf("error parsing patch version '%s' : %s", match[3], err)
+			return fmt.Errorf("error parsing patch version '%s': %w", match[3], err)
 		}
 		patchVersionExists = true
 	}
@@ -236,7 +237,7 @@ func ensureValidGoVersion(version string) error {
 	// then it should be a prerelease
 	if (majorVersion == 1 && minorVersion >= 21) || majorVersion >= 2 {
 		if !patchVersionExists && preRelease == "" {
-			return fmt.Errorf("patch version should always be present for go language version >= 1.21")
+			return errors.New("patch version should always be present for go language version >= 1.21")
 		}
 	}
 

--- a/cmd/publishing-bot/github.go
+++ b/cmd/publishing-bot/github.go
@@ -48,7 +48,7 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 	// who am I?
 	myself, resp, err := client.Users.Get(ctx, "")
 	if err != nil {
-		return fmt.Errorf("failed to get own user: %v", err)
+		return fmt.Errorf("failed to get own user: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get own user: HTTP code %d", resp.StatusCode)
@@ -61,7 +61,7 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 		Body: &body,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to comment on issue #%d: %v", issue, err)
+		return fmt.Errorf("failed to comment on issue #%d: %w", issue, err)
 	}
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("failed to comment on issue #%d: HTTP code %d", issue, resp.StatusCode)
@@ -72,7 +72,7 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 		ListOptions: github.ListOptions{PerPage: 100},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get github comments of issue #%d: %v", issue, err)
+		return fmt.Errorf("failed to get github comments of issue #%d: %w", issue, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get github comments of issue #%d: HTTP code %d", issue, resp.StatusCode)
@@ -89,7 +89,7 @@ func ReportOnIssue(e error, logs, token, org, repo string, issue int) error {
 		glog.Infof("Deleting comment %d", *c.ID)
 		resp, err = client.Issues.DeleteComment(ctx, org, repo, *c.ID)
 		if err != nil {
-			return fmt.Errorf("failed to delete github comment %d of issue #%d: %v", *c.ID, issue, err)
+			return fmt.Errorf("failed to delete github comment %d of issue #%d: %w", *c.ID, issue, err)
 		}
 		if resp.StatusCode >= 300 {
 			return fmt.Errorf("failed to delete github comment %d of issue #%d: HTTP code %d", *c.ID, issue, resp.StatusCode)
@@ -107,7 +107,7 @@ func CloseIssue(token, org, repo string, issue int) error {
 		State: github.String("closed"),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to close issue #%d: %v", issue, err)
+		return fmt.Errorf("failed to close issue #%d: %w", issue, err)
 	}
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("failed to close issue #%d: HTTP code %d", issue, resp.StatusCode)

--- a/cmd/publishing-bot/main.go
+++ b/cmd/publishing-bot/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -211,7 +212,8 @@ func main() {
 			// In production, the bot will not exit with a non-zero exit code, since
 			// the interval will be always non-zero
 			if publisherErr != nil {
-				if exitErr, ok := publisherErr.(*exec.ExitError); ok {
+				var exitErr *exec.ExitError
+				if errors.As(publisherErr, &exitErr) {
 					os.Exit(exitErr.ExitCode())
 				}
 

--- a/cmd/update-rules/main.go
+++ b/cmd/update-rules/main.go
@@ -111,11 +111,11 @@ func main() {
 func load(rulesFile string) (*config.RepositoryRules, error) {
 	rules, err := config.LoadRules(rulesFile)
 	if err != nil {
-		return nil, fmt.Errorf("error loading rules file %q: %v", rulesFile, err)
+		return nil, fmt.Errorf("error loading rules file %q: %w", rulesFile, err)
 	}
 
 	if err := config.Validate(rules); err != nil {
-		return nil, fmt.Errorf("invalid rules file %q: %v", rulesFile, err)
+		return nil, fmt.Errorf("invalid rules file %q: %w", rulesFile, err)
 	}
 	return rules, nil
 }

--- a/cmd/validate-rules/staging/validate.go
+++ b/cmd/validate-rules/staging/validate.go
@@ -67,7 +67,7 @@ func checkDirectoryExistsInBranch(directory, branch string) error {
 		files, err = fetchKubernetesStagingDirectoryFiles(branch)
 		if err != nil {
 			globalMapBranchDirectories[branch] = []File{}
-			return fmt.Errorf("error fetching directories from branch %s : %w", branch, err)
+			return fmt.Errorf("error fetching directories from branch %s: %w", branch, err)
 		}
 		globalMapBranchDirectories[branch] = files
 	}

--- a/pkg/git/mainline.go
+++ b/pkg/git/mainline.go
@@ -36,7 +36,7 @@ func FirstParent(r *gogit.Repository, c *object.Commit) (*object.Commit, error) 
 	}
 	p, err := cache.CommitObject(r, c.ParentHashes[0])
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %v: %v", c.ParentHashes[0], err)
+		return nil, fmt.Errorf("failed to get %v: %w", c.ParentHashes[0], err)
 	}
 	return p, nil
 }
@@ -55,7 +55,7 @@ func FirstParentList(r *gogit.Repository, c *object.Commit) ([]*object.Commit, e
 		// continue with first parent if there is one
 		next, err := FirstParent(r, c)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get first parent of %s: %v", c.Hash, err)
+			return nil, fmt.Errorf("failed to get first parent of %s: %w", c.Hash, err)
 		}
 		c = next
 	}
@@ -96,7 +96,7 @@ func MergePoints(r *gogit.Repository, mainLine []*object.Commit) (map[plumbing.H
 			var err error
 			c, err = cache.CommitObject(r, h)
 			if err != nil {
-				return fmt.Errorf("failed to get %s: %v", h.String(), err)
+				return fmt.Errorf("failed to get %s: %w", h.String(), err)
 			}
 			seen[h] = c
 		}

--- a/pkg/git/mapping.go
+++ b/pkg/git/mapping.go
@@ -46,7 +46,7 @@ func SourceCommitToDstCommits(r *gogit.Repository, commitMsgTag string, dstFirst
 	// compute merge point table
 	kubeMergePoints, err := MergePoints(r, srcFirstParents)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build merge point table: %v", err)
+		return nil, fmt.Errorf("failed to build merge point table: %w", err)
 	}
 
 	// convert dstFirstParents to HashesWithKubeHashes

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -71,7 +71,7 @@ func InstallGoVersions(rules *config.RepositoryRules) error {
 	goLink, target := filepath.Join(systemGoPath, "go"), filepath.Join(systemGoPath, "go-"+defaultGoVersion)
 	os.Remove(goLink)
 	if err := os.Symlink(target, goLink); err != nil {
-		return fmt.Errorf("failed to link %s to %s: %s", goLink, target, err)
+		return fmt.Errorf("failed to link %s to %s: %w", goLink, target, err)
 	}
 
 	return nil
@@ -100,7 +100,7 @@ func installGoVersion(v, pth string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("command %q failed: %v", strings.Join(cmd.Args, " "), err)
+		return fmt.Errorf("command %q failed: %w", strings.Join(cmd.Args, " "), err)
 	}
 
 	return os.Rename(tmpPath, pth)


### PR DESCRIPTION
Use the golang native error wrapping and adapt the linter config based on that.

cc @kubernetes/release-engineering 