### PR TITLE
Use `PULL_BASE_REF` for branch rules validation

### DIFF
--- a/cmd/validate-rules/main.go
+++ b/cmd/validate-rules/main.go
@@ -18,11 +18,14 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/golang/glog"
 	"k8s.io/publishing-bot/cmd/publishing-bot/config"
 	"k8s.io/publishing-bot/cmd/validate-rules/staging"
 )
+
+const baseRefEnvKey = "PULL_BASE_REF"
 
 func main() {
 	flag.Parse()
@@ -39,10 +42,10 @@ func main() {
 		if err := config.Validate(rules); err != nil {
 			glog.Fatalf("Invalid rules file %q: %v", f, err)
 		}
-		errors := staging.EnsureStagingDirectoriesExist(rules)
+		errors := staging.EnsureStagingDirectoriesExist(rules, os.Getenv(baseRefEnvKey))
 		if errors != nil {
 			for _, err := range errors {
-				glog.Errorf("Error : %s", err)
+				glog.Errorf("Error: %s", err)
 			}
 			glog.Fatalf("Invalid rules file %q", f)
 		}


### PR DESCRIPTION
We now consider the `PULL_BASE_REF` (which is set by prow but for testing can also be empty) to:

- Check all rules when running on `master`
- Check only branch specific rules for release branches

Fixes https://github.com/kubernetes/publishing-bot/issues/433

cc @kubernetes/release-engineering 