### PR TITLE
update git package to 1:2.39.5-0+deb12u1 for security fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM debian:bookworm
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.39.2-1.1 \
+ && apt-get install -y -qq git=1:2.39.5-0+deb12u1 \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
debian git package had a security release.
https://lists.debian.org/debian-security-announce/2024/msg00182.html

This also fixes the pull-publishing-bot-image job failure. Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/publishing-bot/449/pull-publishing-bot-image/1837357181154889728