### PR TITLE
update go minimal version to go1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/publishing-bot
 
-go 1.22.7
+go 1.23.0
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
- update go minimal version to go1.23.0 as 1.22 is out of support and dependencies now need 1.23 as the minimal version