### PR TITLE
update git version to 2.39.5-0+deb12u2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM debian:bookworm
 MAINTAINER Stefan Schimanski <sttts@redhat.com>
 RUN apt-get update \
- && apt-get install -y -qq git=1:2.39.5-0+deb12u1 \
+ && apt-get install -y -qq git=1:2.39.5-0+deb12u2 \
  && apt-get install -y -qq mercurial \
  && apt-get install -y -qq ca-certificates curl wget jq vim tmux bsdmainutils tig gcc zip \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
A new debian version of git is available in the debian packages, which was updated as part of a security fix.
CHANGELOG: https://metadata.ftp-master.debian.org/changelogs//main/g/git/git_2.39.5-0+deb12u2_changelog