### PR TITLE
Change all Make targets to PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ push-image:
 	docker push $(DOCKER_REPO):$(GIT_TAG)
 	docker push $(DOCKER_REPO):$(IMG_VERSION)
 	docker push $(DOCKER_REPO):latest
+.PHONY: push-image
 
 build-and-push-image: build-image push-image
 .PHONY: build-and-push-image
@@ -94,16 +95,20 @@ init-deploy: validate
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-configmap.yaml
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f $(CONFIG)-rules-configmap.yaml; \
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/pvc.yaml
+.PHONY: init-deploy
 
 run: init-deploy
 	{ cat artifacts/manifests/pod.yaml && sed 's/^/  /' artifacts/manifests/podspec.yaml; } | \
 	$(call prepare_spec) | $(KUBECTL) apply -n "$(NAMESPACE)" -f -
+.PHONY: run
 
 deploy: init-deploy
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f artifacts/manifests/service.yaml
 	{ cat artifacts/manifests/rs.yaml && sed 's/^/      /' artifacts/manifests/podspec.yaml; } | \
 	$(call prepare_spec) | sed 's/-interval=0/-interval=$(INTERVAL)/g' | \
 	$(KUBECTL) apply -n "$(NAMESPACE)" -f -
+.PHONY: deploy
 
 test: ## Run go tests
 	go test -v -coverprofile=coverage.out ./...
+.PHONY: test


### PR DESCRIPTION
I noticed that not all Make targets are `PHONY` which makes them impossible to run. We're facing that in the CI as well where `pull-publishing-bot-test` is never being ran, i.e. it always shows this instead of running tests:

```
make: 'test' is up to date.
```

(e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/publishing-bot/504/pull-publishing-bot-test/1963877011260706816)

This PR makes all Makefile targets `PHONY` which should fix such issues.

/assign @dims @sttts 
cc @kubernetes/release-engineering 