### PR TITLE
Add GitHub Action for building and pushing images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,61 @@
+name: Build and push image
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/push-image.yml
+      - Dockerfile
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ toLower(github.repository) }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR adds a GitHub Action for building and pushing images. The image is built using `docker buildx` and pushed to GHCR as `ghcr.io/kcp-dev/publishing-bot`. The image is built for AMD64 and ARM64 platforms. Tags in use are:

- `latest` - when pushing to `master`
- tag name - when pushing a tag
- commit's SHA - in all cases

We're pushing the `latest` tag because it makes configuring and running `publishing-bot` easier. If we were using only SHA or tag, we would have to change the publishing-bot configuration in a separate PR after each successful push; I don't think we really need that here, we can just use latest.

The action is ran on pull requests for changes to this action and Dockerfile, on each push to `master`, and on semver tags. Push is done only for pushes to `master` and on semver tags.

Note: I'll create a follow up PR to update Makefile to use `docker buildx`

/assign @xrstf 